### PR TITLE
Replace checkboxes with tri-state boxes

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/components/DateHeader.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/components/DateHeader.kt
@@ -7,7 +7,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Checkbox
+import androidx.compose.material3.TriStateCheckbox
+import androidx.compose.ui.state.ToggleableState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -39,9 +40,15 @@ fun DateHeader(
             )
         }
         val allFilesForDateSelected : Boolean = files.all { fileSelectionStates[it] == true }
-        Checkbox(modifier = Modifier.bounceClick() , checked = allFilesForDateSelected , onCheckedChange = { isChecked ->
+        val noneSelected: Boolean = files.none { fileSelectionStates[it] == true }
+        val toggleState = when {
+            allFilesForDateSelected -> ToggleableState.On
+            noneSelected -> ToggleableState.Off
+            else -> ToggleableState.Indeterminate
+        }
+        TriStateCheckbox(modifier = Modifier.bounceClick() , state = toggleState , onClick = {
             view.playSoundEffect(SoundEffectConstants.CLICK)
-            onDateSelectionChange(files, isChecked)
+            onDateSelectionChange(files, toggleState != ToggleableState.On)
         })
     }
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/components/tabs/TabsContent.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/components/tabs/TabsContent.kt
@@ -11,7 +11,8 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Close
-import androidx.compose.material3.Checkbox
+import androidx.compose.material3.TriStateCheckbox
+import androidx.compose.ui.state.ToggleableState
 import androidx.compose.material3.ScrollableTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRowDefaults
@@ -67,8 +68,17 @@ fun TabsContent(
             tabs.forEachIndexed { index , title ->
                 val allFilesInCategory : List<File> = groupedFiles[title] ?: emptyList()
                 val duplicateOriginals = data.analyzeState.duplicateOriginals
-                val isCategoryChecked : Boolean = allFilesInCategory.filterNot { it in duplicateOriginals }.all { file ->
+                val filesWithoutOriginals = allFilesInCategory.filterNot { it in duplicateOriginals }
+                val allCategorySelected = filesWithoutOriginals.all { file ->
                     data.analyzeState.fileSelectionMap[file] == true
+                }
+                val noneSelected = filesWithoutOriginals.none { file ->
+                    data.analyzeState.fileSelectionMap[file] == true
+                }
+                val toggleState = when {
+                    allCategorySelected -> ToggleableState.On
+                    noneSelected -> ToggleableState.Off
+                    else -> ToggleableState.Indeterminate
                 }
 
                 Tab(modifier = Modifier
@@ -82,7 +92,7 @@ fun TabsContent(
                     Row(
                         verticalAlignment = Alignment.CenterVertically , horizontalArrangement = Arrangement.Start
                     ) {
-                        Checkbox(checked = isCategoryChecked , onCheckedChange = {
+                        TriStateCheckbox(state = toggleState , onClick = {
                             viewModel.toggleSelectFilesForCategory(category = title)
                         })
                         Text(text = title)

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/WhatsAppDetailsScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/WhatsAppDetailsScreen.kt
@@ -29,7 +29,8 @@ import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.FolderOff
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
-import androidx.compose.material3.Checkbox
+import androidx.compose.material3.TriStateCheckbox
+import androidx.compose.ui.state.ToggleableState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -376,9 +377,9 @@ fun DetailsScreenContent(
                                         )
                                     }
                             )
-                            Checkbox(
-                                checked = checked,
-                                onCheckedChange = {
+                            TriStateCheckbox(
+                                state = if (checked) ToggleableState.On else ToggleableState.Off,
+                                onClick = {
                                     if (checked) selected.remove(file) else selected.add(file)
                                 },
                                 modifier = Modifier.align(Alignment.TopEnd)
@@ -415,9 +416,9 @@ fun DetailsScreenContent(
                             } else {
                                 FileListItem(file = file, modifier = Modifier.weight(1f))
                             }
-                            Checkbox(
-                                checked = checked,
-                                onCheckedChange = {
+                            TriStateCheckbox(
+                                state = if (checked) ToggleableState.On else ToggleableState.Off,
+                                onClick = {
                                     if (checked) selected.remove(file) else selected.add(file)
                                 },
                                 modifier = Modifier.align(Alignment.CenterVertically)
@@ -471,9 +472,9 @@ private fun SmartSuggestionsCard(
                                     )
                                 }
                         )
-                        Checkbox(
-                            checked = checked,
-                            onCheckedChange = {
+                        TriStateCheckbox(
+                            state = if (checked) ToggleableState.On else ToggleableState.Off,
+                            onClick = {
                                 if (checked) selected.remove(file) else selected.add(file)
                             },
                             modifier = Modifier.align(Alignment.TopEnd)

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/components/CustomTabLayout.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/components/CustomTabLayout.kt
@@ -5,7 +5,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Checkbox
+import androidx.compose.material3.TriStateCheckbox
+import androidx.compose.ui.state.ToggleableState
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRowDefaults
@@ -40,7 +41,13 @@ fun CustomTabLayout(
     ) {
         items.forEachIndexed { index, text ->
             val files = filesPerTab.getOrNull(index) ?: emptyList()
-            val isChecked = files.isNotEmpty() && files.all { it in selectedFiles }
+            val allSelected = files.isNotEmpty() && files.all { it in selectedFiles }
+            val noneSelected = files.none { it in selectedFiles }
+            val toggleState = when {
+                allSelected -> ToggleableState.On
+                noneSelected -> ToggleableState.Off
+                else -> ToggleableState.Indeterminate
+            }
 
             Tab(
                 modifier = Modifier
@@ -52,9 +59,11 @@ fun CustomTabLayout(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.Start
                     ) {
-                        Checkbox(
-                            checked = isChecked,
-                            onCheckedChange = { onTabCheckedChange(index, it) },
+                        TriStateCheckbox(
+                            state = toggleState,
+                            onClick = {
+                                onTabCheckedChange(index, toggleState != ToggleableState.On)
+                            },
                         )
                         Text(
                             modifier = Modifier.basicMarquee(),


### PR DESCRIPTION
## Summary
- use `TriStateCheckbox` for analyzing tabs
- apply tri-state behaviour to Whatsapp custom tab layout
- switch date header selection to tri-state
- use tri-state checkboxes for file selections in details screen

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880fa14cb70832dbf4af90f7de95a5e