### PR TITLE
Add System Storage Manager shortcut

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/SystemStorageManagerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/SystemStorageManagerCard.kt
@@ -1,0 +1,61 @@
+package com.d4rk.cleaner.app.clean.scanner.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Launch
+import androidx.compose.material.icons.outlined.Storage
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.TonalIconButtonWithText
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+import com.d4rk.cleaner.R
+
+@Composable
+fun SystemStorageManagerCard(modifier: Modifier = Modifier, onOpen: () -> Unit) {
+    OutlinedCard(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(SizeConstants.ExtraLargeSize),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(SizeConstants.LargeSize),
+            verticalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Outlined.Storage,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary
+                )
+                Column(modifier = Modifier.padding(start = SizeConstants.MediumSize)) {
+                    Text(
+                        text = stringResource(id = R.string.storage_manager_card_title),
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                    Text(
+                        text = stringResource(id = R.string.storage_manager_card_subtitle),
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+            }
+            TonalIconButtonWithText(
+                label = stringResource(id = R.string.open_storage_manager),
+                icon = Icons.Outlined.Launch,
+                onClick = onOpen,
+                modifier = Modifier.align(Alignment.End)
+            )
+        }
+    }
+}

--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -174,6 +174,9 @@
     <string name="contacts_cleaner_card_title">منظف جهات الاتصال</string>
     <string name="contacts_cleaner_card_subtitle">اعثر على جهات الاتصال المكررة وادمجها</string>
     <string name="open_contacts_cleaner">افتح منظف جهات الاتصال</string>
+    <string name="storage_manager_card_title">مدير تخزين النظام</string>
+    <string name="storage_manager_card_subtitle">إدارة المساحة باستخدام الأدوات المدمجة.</string>
+    <string name="open_storage_manager">فتح مدير التخزين</string>
     <string name="scan_cache">فحص الكاش</string>
     <string name="apks">ملفات APK</string>
     <string name="archives">الملفات المضغوطة</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -162,6 +162,9 @@
     <string name="contacts_cleaner_card_title">Почистване на контакти</string>
     <string name="contacts_cleaner_card_subtitle">Намира и обединява дублирани контакти</string>
     <string name="open_contacts_cleaner">Отвори чистач на контакти</string>
+    <string name="storage_manager_card_title">Системен мениджър на хранилището</string>
+    <string name="storage_manager_card_subtitle">Управлявайте мястото с вградените инструменти.</string>
+    <string name="open_storage_manager">Отвори мениджъра на хранилището</string>
     <string name="scan_cache">Сканирай кеша</string>
     <string name="apks">APK файлове</string>
     <string name="archives">Архиви</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -162,6 +162,9 @@
     <string name="contacts_cleaner_card_title">কন্টাক্টস ক্লিনার</string>
     <string name="contacts_cleaner_card_subtitle">নকল কন্টাক্ট খুঁজে মিশিয়ে দিন</string>
     <string name="open_contacts_cleaner">কন্টাক্টস ক্লিনার খুলুন</string>
+    <string name="storage_manager_card_title">সিস্টেম স্টোরেজ ম্যানেজার</string>
+    <string name="storage_manager_card_subtitle">অন্তর্নির্মিত টুল দিয়ে জায়গা ব্যবস্থাপনা করুন।</string>
+    <string name="open_storage_manager">স্টোরেজ ম্যানেজার খুলুন</string>
     <string name="scan_cache">ক্যাশে স্ক্যান করুন</string>
     <string name="apks">এপিকে ফাইল</string>
     <string name="archives">আর্কাইভসমূহ</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -162,6 +162,9 @@
     <string name="contacts_cleaner_card_title">Kontaktbereinigung</string>
     <string name="contacts_cleaner_card_subtitle">Doppelte Kontakte finden und zusammenführen</string>
     <string name="open_contacts_cleaner">Kontaktbereinigung öffnen</string>
+    <string name="storage_manager_card_title">Systemspeicher-Manager</string>
+    <string name="storage_manager_card_subtitle">Verwalte den Speicher mit den integrierten Tools.</string>
+    <string name="open_storage_manager">Speicherverwaltung öffnen</string>
     <string name="scan_cache">Cache scannen</string>
     <string name="apks">APKs</string>
     <string name="archives">Archive</string>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -165,6 +165,9 @@
     <string name="contacts_cleaner_card_title">Limpiador de contactos</string>
     <string name="contacts_cleaner_card_subtitle">Busca y combina contactos duplicados</string>
     <string name="open_contacts_cleaner">Abrir Limpiador de contactos</string>
+    <string name="storage_manager_card_title">Administrador de almacenamiento del sistema</string>
+    <string name="storage_manager_card_subtitle">Administra el espacio con las herramientas integradas.</string>
+    <string name="open_storage_manager">Abrir Administrador de almacenamiento</string>
     <string name="scan_cache">Escanear caché</string>
     <string name="apks">APKs</string>
     <string name="archives">Archivos comprimidos</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -165,6 +165,9 @@
     <string name="contacts_cleaner_card_title">Limpiador de contactos</string>
     <string name="contacts_cleaner_card_subtitle">Busca y combina contactos duplicados</string>
     <string name="open_contacts_cleaner">Abrir Limpiador de contactos</string>
+    <string name="storage_manager_card_title">Administrador de almacenamiento del sistema</string>
+    <string name="storage_manager_card_subtitle">Administra espacio con las herramientas integradas.</string>
+    <string name="open_storage_manager">Abrir Administrador de almacenamiento</string>
     <string name="scan_cache">Escanear caché</string>
     <string name="apks">APKs</string>
     <string name="archives">Archivos comprimidos</string>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -162,6 +162,9 @@
     <string name="contacts_cleaner_card_title">Panglinis ng Contacts</string>
     <string name="contacts_cleaner_card_subtitle">Hanapin at pagsamahin ang mga dobleng contact</string>
     <string name="open_contacts_cleaner">Buksan ang Contacts Cleaner</string>
+    <string name="storage_manager_card_title">Tagapamahala ng Imbakan ng Sistema</string>
+    <string name="storage_manager_card_subtitle">Pamahalaan ang espasyo gamit ang mga kasangkapang nakapaloob.</string>
+    <string name="open_storage_manager">Buksan ang Storage Manager</string>
     <string name="scan_cache">I-scan ang Cache</string>
     <string name="apks">Mga APK</string>
     <string name="archives">Mga Archive</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -165,6 +165,9 @@
     <string name="contacts_cleaner_card_title">Nettoyeur de contacts</string>
     <string name="contacts_cleaner_card_subtitle">Trouver et fusionner les contacts en double</string>
     <string name="open_contacts_cleaner">Ouvrir le Nettoyeur de contacts</string>
+    <string name="storage_manager_card_title">Gestionnaire de stockage système</string>
+    <string name="storage_manager_card_subtitle">Gérez l’espace avec les outils intégrés.</string>
+    <string name="open_storage_manager">Ouvrir le Gestionnaire de stockage</string>
     <string name="scan_cache">Analyser le cache</string>
     <string name="apks">APK</string>
     <string name="archives">Archives</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -162,6 +162,9 @@
     <string name="contacts_cleaner_card_title">संपर्क क्लीनर</string>
     <string name="contacts_cleaner_card_subtitle">डुप्लीकेट संपर्क खोजें और मिलाएँ</string>
     <string name="open_contacts_cleaner">संपर्क क्लीनर खोलें</string>
+    <string name="storage_manager_card_title">सिस्टम स्टोरेज प्रबंधक</string>
+    <string name="storage_manager_card_subtitle">बिल्ट-इन टूल से स्थान प्रबंधित करें।</string>
+    <string name="open_storage_manager">स्टोरेज प्रबंधक खोलें</string>
     <string name="scan_cache">कैश स्कैन करें</string>
     <string name="apks">एपीके</string>
     <string name="archives">अभिलेखागार</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -162,6 +162,9 @@
     <string name="contacts_cleaner_card_title">Névjegytisztító</string>
     <string name="contacts_cleaner_card_subtitle">Keresse meg és egyesítse a duplikált névjegyeket</string>
     <string name="open_contacts_cleaner">Névjegytisztító megnyitása</string>
+    <string name="storage_manager_card_title">Rendszer tárhelykezelő</string>
+    <string name="storage_manager_card_subtitle">Kezeld a helyet a beépített eszközökkel.</string>
+    <string name="open_storage_manager">Tárhelykezelő megnyitása</string>
     <string name="scan_cache">Gyorsítótár vizsgálata</string>
     <string name="apks">APK-k</string>
     <string name="archives">Archívumok</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -159,6 +159,9 @@
     <string name="contacts_cleaner_card_title">Pembersih Kontak</string>
     <string name="contacts_cleaner_card_subtitle">Temukan dan gabungkan kontak ganda</string>
     <string name="open_contacts_cleaner">Buka Pembersih Kontak</string>
+    <string name="storage_manager_card_title">Manajer Penyimpanan Sistem</string>
+    <string name="storage_manager_card_subtitle">Kelola ruang menggunakan alat bawaan.</string>
+    <string name="open_storage_manager">Buka Manajer Penyimpanan</string>
     <string name="scan_cache">Pindai Cache</string>
     <string name="apks">APK</string>
     <string name="archives">Arsip</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -165,6 +165,9 @@
     <string name="contacts_cleaner_card_title">Pulizia contatti</string>
     <string name="contacts_cleaner_card_subtitle">Trova e unisci i contatti duplicati</string>
     <string name="open_contacts_cleaner">Apri Pulizia contatti</string>
+    <string name="storage_manager_card_title">Gestore archiviazione di sistema</string>
+    <string name="storage_manager_card_subtitle">Gestisci lo spazio con gli strumenti integrati.</string>
+    <string name="open_storage_manager">Apri Gestore archiviazione</string>
     <string name="scan_cache">Scansione cache</string>
     <string name="apks">APK</string>
     <string name="archives">Archivi</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -159,6 +159,9 @@
     <string name="contacts_cleaner_card_title">連絡先クリーナー</string>
     <string name="contacts_cleaner_card_subtitle">重複した連絡先を検出して統合</string>
     <string name="open_contacts_cleaner">連絡先クリーナーを開く</string>
+    <string name="storage_manager_card_title">システムストレージマネージャー</string>
+    <string name="storage_manager_card_subtitle">組み込みツールで空き容量を管理します。</string>
+    <string name="open_storage_manager">ストレージマネージャーを開く</string>
     <string name="scan_cache">キャッシュをスキャン</string>
     <string name="apks">APK</string>
     <string name="archives">アーカイブ</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -159,6 +159,9 @@
     <string name="contacts_cleaner_card_title">연락처 클리너</string>
     <string name="contacts_cleaner_card_subtitle">중복 연락처 찾기 및 병합</string>
     <string name="open_contacts_cleaner">연락처 클리너 열기</string>
+    <string name="storage_manager_card_title">시스템 저장소 관리자</string>
+    <string name="storage_manager_card_subtitle">내장 도구로 공간을 관리하세요.</string>
+    <string name="open_storage_manager">저장소 관리자 열기</string>
     <string name="scan_cache">캐시 스캔</string>
     <string name="apks">APK</string>
     <string name="archives">압축 파일</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -168,6 +168,9 @@
     <string name="contacts_cleaner_card_title">Czyszczenie kontaktów</string>
     <string name="contacts_cleaner_card_subtitle">Znajdź i połącz zduplikowane kontakty</string>
     <string name="open_contacts_cleaner">Otwórz czyszczenie kontaktów</string>
+    <string name="storage_manager_card_title">Systemowy menedżer pamięci</string>
+    <string name="storage_manager_card_subtitle">Zarządzaj miejscem za pomocą wbudowanych narzędzi.</string>
+    <string name="open_storage_manager">Otwórz menedżera pamięci</string>
     <string name="scan_cache">Skanuj pamięć podręczną</string>
     <string name="apks">Pliki APK</string>
     <string name="archives">Archiwa</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -165,6 +165,9 @@
     <string name="contacts_cleaner_card_title">Limpeza de contatos</string>
     <string name="contacts_cleaner_card_subtitle">Encontre e mescle contatos duplicados</string>
     <string name="open_contacts_cleaner">Abrir Limpeza de contatos</string>
+    <string name="storage_manager_card_title">Gerenciador de armazenamento do sistema</string>
+    <string name="storage_manager_card_subtitle">Gerencie espaço com as ferramentas integradas.</string>
+    <string name="open_storage_manager">Abrir Gerenciador de armazenamento</string>
     <string name="scan_cache">Escanear cache</string>
     <string name="apks">APKs</string>
     <string name="archives">Arquivos Compactados</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -165,6 +165,9 @@
     <string name="contacts_cleaner_card_title">Curățător contacte</string>
     <string name="contacts_cleaner_card_subtitle">Găsește și combină contactele duplicate</string>
     <string name="open_contacts_cleaner">Deschide Curățător contacte</string>
+    <string name="storage_manager_card_title">Manager de stocare al sistemului</string>
+    <string name="storage_manager_card_subtitle">Gestionează spațiul cu instrumentele integrate.</string>
+    <string name="open_storage_manager">Deschide Managerul de stocare</string>
     <string name="scan_cache">Scanează cache-ul</string>
     <string name="apks">APK-uri</string>
     <string name="archives">Arhive</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -168,6 +168,9 @@
     <string name="contacts_cleaner_card_title">Очистка контактов</string>
     <string name="contacts_cleaner_card_subtitle">Находит и объединяет повторяющиеся контакты</string>
     <string name="open_contacts_cleaner">Открыть очистку контактов</string>
+    <string name="storage_manager_card_title">Системный менеджер хранилища</string>
+    <string name="storage_manager_card_subtitle">Управляйте местом с помощью встроенных инструментов.</string>
+    <string name="open_storage_manager">Открыть менеджер хранилища</string>
     <string name="scan_cache">Сканировать кеш</string>
     <string name="apks">APK</string>
     <string name="archives">Архивы</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -162,6 +162,9 @@
     <string name="contacts_cleaner_card_title">Kontaktrensare</string>
     <string name="contacts_cleaner_card_subtitle">Hitta och slå ihop dubbla kontakter</string>
     <string name="open_contacts_cleaner">Öppna Kontaktrensare</string>
+    <string name="storage_manager_card_title">Systemets lagringshanterare</string>
+    <string name="storage_manager_card_subtitle">Hantera utrymmet med de inbyggda verktygen.</string>
+    <string name="open_storage_manager">Öppna lagringshanteraren</string>
     <string name="scan_cache">Skanna cache</string>
     <string name="apks">APK:er</string>
     <string name="archives">Arkiv</string>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -159,6 +159,9 @@
     <string name="contacts_cleaner_card_title">ตัวล้างรายชื่อ</string>
     <string name="contacts_cleaner_card_subtitle">ค้นหาและรวมรายชื่อที่ซ้ำกัน</string>
     <string name="open_contacts_cleaner">เปิดตัวล้างรายชื่อ</string>
+    <string name="storage_manager_card_title">ตัวจัดการที่เก็บข้อมูลระบบ</string>
+    <string name="storage_manager_card_subtitle">จัดการพื้นที่ด้วยเครื่องมือในตัว.</string>
+    <string name="open_storage_manager">เปิดตัวจัดการที่เก็บข้อมูล</string>
     <string name="scan_cache">สแกนแคช</string>
     <string name="apks">ไฟล์ APK</string>
     <string name="archives">ไฟล์เก็บถาวร</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -162,6 +162,9 @@
     <string name="contacts_cleaner_card_title">Kişi Temizleyici</string>
     <string name="contacts_cleaner_card_subtitle">Yinelenen kişileri bulup birleştirin</string>
     <string name="open_contacts_cleaner">Kişi Temizleyici\'yi aç</string>
+    <string name="storage_manager_card_title">Sistem Depolama Yöneticisi</string>
+    <string name="storage_manager_card_subtitle">Yerleşik araçlarla alanı yönetin.</string>
+    <string name="open_storage_manager">Depolama Yöneticisini aç</string>
     <string name="scan_cache">Önbelleği Tara</string>
     <string name="apks">APK\'lar</string>
     <string name="archives">Arşivler</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -168,6 +168,9 @@
     <string name="contacts_cleaner_card_title">Очищення контактів</string>
     <string name="contacts_cleaner_card_subtitle">Знаходить і об\'єднує дублікати контактів</string>
     <string name="open_contacts_cleaner">Відкрити очищення контактів</string>
+    <string name="storage_manager_card_title">Системний менеджер сховища</string>
+    <string name="storage_manager_card_subtitle">Керуйте місцем за допомогою вбудованих інструментів.</string>
+    <string name="open_storage_manager">Відкрити менеджер сховища</string>
     <string name="scan_cache">Сканувати кеш</string>
     <string name="apks">APK-файли</string>
     <string name="archives">Архіви</string>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -162,6 +162,9 @@
     <string name="contacts_cleaner_card_title">کانٹیکٹ کلینر</string>
     <string name="contacts_cleaner_card_subtitle">ڈپلیکیٹ کانٹیکٹس تلاش کریں اور ملائیں</string>
     <string name="open_contacts_cleaner">کانٹیکٹ کلینر کھولیں</string>
+    <string name="storage_manager_card_title">سسٹم اسٹوریج مینیجر</string>
+    <string name="storage_manager_card_subtitle">بلٹ ان ٹولز سے جگہ کا انتظام کریں۔</string>
+    <string name="open_storage_manager">اسٹوریج مینیجر کھولیں</string>
     <string name="scan_cache">کیچ اسکین کریں</string>
     <string name="apks">APK فائلیں</string>
     <string name="archives">آرکائیوز</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -159,6 +159,9 @@
     <string name="contacts_cleaner_card_title">Trình dọn liên hệ</string>
     <string name="contacts_cleaner_card_subtitle">Tìm và gộp các liên hệ trùng</string>
     <string name="open_contacts_cleaner">Mở Trình dọn liên hệ</string>
+    <string name="storage_manager_card_title">Trình quản lý bộ nhớ hệ thống</string>
+    <string name="storage_manager_card_subtitle">Quản lý dung lượng bằng công cụ tích hợp.</string>
+    <string name="open_storage_manager">Mở Trình quản lý bộ nhớ</string>
     <string name="scan_cache">Quét bộ nhớ đệm</string>
     <string name="apks">Tệp APK</string>
     <string name="archives">Tệp nén</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -159,6 +159,9 @@
     <string name="contacts_cleaner_card_title">聯絡人清理</string>
     <string name="contacts_cleaner_card_subtitle">尋找並合併重複的聯絡人</string>
     <string name="open_contacts_cleaner">開啟聯絡人清理</string>
+    <string name="storage_manager_card_title">系統儲存管理員</string>
+    <string name="storage_manager_card_subtitle">使用內建工具管理空間。</string>
+    <string name="open_storage_manager">開啟儲存管理員</string>
     <string name="scan_cache">掃描快取</string>
     <string name="apks">APK</string>
     <string name="archives">壓縮檔</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -164,6 +164,9 @@
     <string name="contacts_cleaner_card_title">Contacts Cleaner</string>
     <string name="contacts_cleaner_card_subtitle">Find and merge duplicate contacts</string>
     <string name="open_contacts_cleaner">Open Contacts Cleaner</string>
+    <string name="storage_manager_card_title">System Storage Manager</string>
+    <string name="storage_manager_card_subtitle">Manage space using the built-in tools.</string>
+    <string name="open_storage_manager">Open Storage Manager</string>
     <string name="scan_cache">Scan Cache</string>
     <string name="apks">APKs</string>
     <string name="archives">Archives</string>


### PR DESCRIPTION
## Summary
- add a System Storage Manager card component
- show the card when the system activity is available
- allow opening Android's storage manager from dashboard
- provide English strings for the new card
- translate storage manager strings for supported locales

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688646f93acc832db8a6273322d1fe38