### PR TITLE
Fix APK loading and empty folder card

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/core/data/datastore/DataStore.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/data/datastore/DataStore.kt
@@ -411,6 +411,18 @@ class DataStore(val context: Context) : CommonDataStore(context = context) {
         }
     }
 
+    private val emptyFoldersHideUntilKey =
+        longPreferencesKey(AppDataStoreConstants.DATA_STORE_EMPTY_FOLDERS_HIDE_UNTIL)
+    val emptyFoldersHideUntil: Flow<Long> = dataStore.data.map { prefs ->
+        prefs[emptyFoldersHideUntilKey] ?: 0L
+    }
+
+    suspend fun saveEmptyFoldersHideUntil(timestamp: Long) {
+        dataStore.edit { prefs ->
+            prefs[emptyFoldersHideUntilKey] = timestamp
+        }
+    }
+
     private val autoCleanEnabledKey =
         booleanPreferencesKey(AppDataStoreConstants.DATA_STORE_AUTO_CLEAN_ENABLED)
     val autoCleanEnabled: Flow<Boolean> = dataStore.data.map { prefs ->

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/constants/datastore/AppDataStoreConstants.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/constants/datastore/AppDataStoreConstants.kt
@@ -36,6 +36,7 @@ object AppDataStoreConstants : DataStoreNamesConstants() {
     const val DATA_STORE_STREAK_REMINDER_ENABLED = "streak_reminder_enabled"
     const val DATA_STORE_SHOW_STREAK_CARD = "show_streak_card"
     const val DATA_STORE_STREAK_HIDE_UNTIL = "streak_hide_until"
+    const val DATA_STORE_EMPTY_FOLDERS_HIDE_UNTIL = "empty_folders_hide_until"
     const val DATA_STORE_AUTO_CLEAN_ENABLED = "auto_clean_enabled"
     const val DATA_STORE_AUTO_CLEAN_FREQUENCY_DAYS = "auto_clean_frequency_days"
 }


### PR DESCRIPTION
## Summary
- prevent APK card from showing loading state when cleaning empty folders
- hide empty folder card for a few minutes after cleaning to avoid immediate reappearance

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688652fa0538832db8139c81d2aa9426