### PR TITLE
Add Link Cleaner feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - **New**: Added quick empty folder cleaner on the dashboard.
 - **New**: Added a shortcut to the System Storage Manager.
+- **New**: Introduced a link cleaner to remove tracking parameters from URLs before sharing.
 - **Minor**: Improved the UI of the Contacts Cleaner screen.
 
 # Version 3.5.0:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ free and open-source software
 - App management
 - WhatsApp media cleaner
 - Clipboard cleaner
+- Link cleaner
 - Image optimization
 - Clean empty folders
 - Clean logs, temporary files, caches, and corpse files

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -117,6 +117,17 @@
             android:exported="true"
             android:label="@string/clipboard_clean"
             android:parentActivityName=".app.main.ui.MainActivity" />
+        <activity
+            android:name=".app.clean.link.ui.LinkCleanerActivity"
+            android:exported="true"
+            android:label="@string/link_cleaner"
+            android:parentActivityName=".app.main.ui.MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/*" />
+            </intent-filter>
+        </activity>
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/dashboard/ui/ScannerDashboardScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/dashboard/ui/ScannerDashboardScreen.kt
@@ -48,6 +48,7 @@ import com.d4rk.cleaner.app.clean.scanner.ui.ScannerViewModel
 import com.d4rk.cleaner.app.clean.scanner.ui.components.ApkCleanerCard
 import com.d4rk.cleaner.app.clean.scanner.ui.components.CacheCleanerCard
 import com.d4rk.cleaner.app.clean.scanner.ui.components.ClipboardCleanerCard
+import com.d4rk.cleaner.app.clean.scanner.ui.components.LinkCleanerCard
 import com.d4rk.cleaner.app.clean.scanner.ui.components.ImageOptimizerCard
 import com.d4rk.cleaner.app.clean.scanner.ui.components.LargeFilesCard
 import com.d4rk.cleaner.app.clean.scanner.ui.components.EmptyFolderCleanerCard
@@ -57,6 +58,7 @@ import com.d4rk.cleaner.app.clean.scanner.ui.components.QuickScanSummaryCard
 import com.d4rk.cleaner.app.clean.scanner.ui.components.WeeklyCleanStreakCard
 import com.d4rk.cleaner.app.clean.scanner.ui.components.WhatsAppCleanerCard
 import com.d4rk.cleaner.app.clean.whatsapp.summary.ui.WhatsAppCleanerActivity
+import com.d4rk.cleaner.app.clean.link.ui.LinkCleanerActivity
 import com.d4rk.cleaner.app.images.picker.ui.ImagePickerActivity
 import com.d4rk.cleaner.core.data.datastore.DataStore
 import org.koin.compose.koinInject
@@ -109,6 +111,7 @@ fun ScannerDashboardScreen(
     val showClipboardCard by remember(clipboardText) {
         derivedStateOf { !clipboardText.isNullOrBlank() }
     }
+    val showLinkCleanerCard = true
     val showLargeFilesCard by remember(largeFiles) {
         derivedStateOf { largeFiles.isNotEmpty() }
     }
@@ -133,6 +136,7 @@ fun ScannerDashboardScreen(
             showWhatsAppCard,
             showApkCard,
             showClipboardCard,
+            showLinkCleanerCard,
             showLargeFilesCard,
             showEmptyFoldersCard,
             showContactsCard
@@ -165,6 +169,7 @@ fun ScannerDashboardScreen(
         showWhatsAppCard,
         showApkCard,
         showClipboardCard,
+        showLinkCleanerCard,
         showContactsCard,
         showSystemStorageManagerCard,
         promotedApp
@@ -183,6 +188,7 @@ fun ScannerDashboardScreen(
             if (showWhatsAppCard) add(true)
             if (showApkCard) add(true)
             if (showClipboardCard) add(true)
+            if (showLinkCleanerCard) add(true)
             if (showLargeFilesCard) add(true)
             if (showEmptyFoldersCard) add(true)
             if (showContactsCard) add(true)
@@ -365,6 +371,31 @@ fun ScannerDashboardScreen(
                         )
                         .animateContentSize(),
                     clipboardText = clipboardText, onCleanClick = { viewModel.onClipboardClear() })
+            }
+        }
+
+        if (showLinkCleanerCard) {
+            AnimatedVisibility(
+                visible = showLinkCleanerCard,
+                enter = DashboardTransitions.enter,
+                exit = DashboardTransitions.exit
+            ) {
+                val linkIndex = nextIndex()
+                LinkCleanerCard(
+                    modifier = Modifier
+                        .animateVisibility(
+                            visible = uiState.data?.analyzeState?.isAnalyzeScreenVisible == false &&
+                                    visibilityStates.getOrElse(index = linkIndex) { false },
+                            index = linkIndex
+                        )
+                        .animateContentSize(),
+                    linkText = null,
+                    onCleanClick = {
+                        IntentsHelper.openActivity(
+                            context = context, activityClass = LinkCleanerActivity::class.java
+                        )
+                    }
+                )
             }
         }
 

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/link/domain/UrlCleaner.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/link/domain/UrlCleaner.kt
@@ -1,0 +1,22 @@
+package com.d4rk.cleaner.app.clean.link.domain
+
+import android.net.Uri
+
+object UrlCleaner {
+    private val trackingParams = setOf(
+        "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content",
+        "fbclid", "gclid", "igshid", "mc_cid", "mc_eid"
+    )
+
+    fun clean(url: String): String {
+        val uri = try { Uri.parse(url) } catch (e: Exception) { return url }
+        if (uri.scheme == null) return url
+        val builder = uri.buildUpon().clearQuery()
+        uri.queryParameterNames
+            .filter { it !in trackingParams }
+            .forEach { param ->
+                builder.appendQueryParameter(param, uri.getQueryParameter(param))
+            }
+        return builder.build().toString()
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/link/ui/LinkCleanerActivity.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/link/ui/LinkCleanerActivity.kt
@@ -1,0 +1,28 @@
+package com.d4rk.cleaner.app.clean.link.ui
+
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import com.d4rk.cleaner.R
+import com.d4rk.cleaner.app.clean.link.domain.UrlCleaner
+
+class LinkCleanerActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val text = intent?.getStringExtra(Intent.EXTRA_TEXT)
+        if (text != null) {
+            val cleaned = UrlCleaner.clean(text)
+            Toast.makeText(this, R.string.link_cleaned, Toast.LENGTH_SHORT).show()
+            val share = Intent(Intent.ACTION_SEND).apply {
+                type = "text/plain"
+                putExtra(Intent.EXTRA_TEXT, cleaned)
+            }
+            startActivity(Intent.createChooser(share, getString(R.string.share_via)))
+        } else {
+            Toast.makeText(this, R.string.something_went_wrong, Toast.LENGTH_SHORT).show()
+        }
+        finishAndRemoveTask()
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/LinkCleanerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/LinkCleanerCard.kt
@@ -1,0 +1,84 @@
+package com.d4rk.cleaner.app.clean.scanner.ui.components
+
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Link
+import androidx.compose.material.icons.outlined.LinkOff
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.TonalIconButtonWithText
+import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.SmallVerticalSpacer
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+import com.d4rk.cleaner.R
+
+@Composable
+fun LinkCleanerCard(
+    linkText: String?,
+    modifier: Modifier = Modifier,
+    onCleanClick: () -> Unit,
+) {
+    OutlinedCard(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(SizeConstants.ExtraLargeSize),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(all = SizeConstants.LargeSize),
+            verticalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Outlined.Link,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary
+                )
+                Column(modifier = Modifier.padding(start = SizeConstants.MediumSize)) {
+                    Text(
+                        text = stringResource(id = R.string.link_cleaner_card_title),
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                    SmallVerticalSpacer()
+                    Text(
+                        text = stringResource(id = R.string.link_cleaner_card_subtitle),
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+            }
+
+            linkText?.let { text ->
+                Text(
+                    text = text,
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.animateContentSize()
+                )
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                TonalIconButtonWithText(
+                    label = stringResource(id = R.string.clean_link),
+                    icon = Icons.Outlined.LinkOff,
+                    onClick = onCleanClick,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -164,6 +164,12 @@
     <string name="clipboard_current_format">الحافظة الحالية: %1$s</string>
     <string name="clean_clipboard">مسح الحافظة</string>
     <string name="clipboard_cleaned">تم تنظيف الحافظة</string>
+    <string name="link_cleaner">منظف الروابط</string>
+    <string name="link_cleaned">تم تنظيف الرابط</string>
+    <string name="link_cleaner_card_title">منظف الروابط</string>
+    <string name="link_cleaner_card_subtitle">إزالة معلمات التتبع من الروابط</string>
+    <string name="clean_link">تنظيف الرابط</string>
+    <string name="share_via">مشاركة عبر</string>
     <string name="cleaner_recommends">يوصي Cleaner</string>
     <string name="image_optimizer_card_title">محسن الصور</string>
     <string name="image_optimizer_card_subtitle">ضغط الصور دون فقدان الجودة.&#10;وفر المساحة بلمسة واحدة.</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -152,6 +152,12 @@
     <string name="clipboard_current_format">Текущ клипборд: %1$s</string>
     <string name="clean_clipboard">Изчисти клипборда</string>
     <string name="clipboard_cleaned">Клипбордът е почистен</string>
+    <string name="link_cleaner">Почистващ връзки</string>
+    <string name="link_cleaned">Връзката е почистена</string>
+    <string name="link_cleaner_card_title">Почистващ връзки</string>
+    <string name="link_cleaner_card_subtitle">Премахнете проследяващите параметри от връзките</string>
+    <string name="clean_link">Почисти връзката</string>
+    <string name="share_via">Сподели чрез</string>
     <string name="cleaner_recommends">Cleaner препоръчва</string>
     <string name="image_optimizer_card_title">Оптимизатор на изображения</string>
     <string name="image_optimizer_card_subtitle">Компресирайте снимки без загуба на качество.&#10;Спестете място с едно докосване.</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -152,6 +152,12 @@
     <string name="clipboard_current_format">বর্তমান ক্লিপবোর্ড: %1$s</string>
     <string name="clean_clipboard">ক্লিপবোর্ড পরিষ্কার করুন</string>
     <string name="clipboard_cleaned">ক্লিপবোর্ড পরিষ্কার করা হয়েছে</string>
+    <string name="link_cleaner">লিঙ্ক ক্লিনার</string>
+    <string name="link_cleaned">লিঙ্ক পরিষ্কার হয়েছে</string>
+    <string name="link_cleaner_card_title">লিঙ্ক ক্লিনার</string>
+    <string name="link_cleaner_card_subtitle">লিঙ্ক থেকে ট্র্যাকিং প্যারামিটার সরান</string>
+    <string name="clean_link">লিঙ্ক পরিষ্কার করুন</string>
+    <string name="share_via">মাধ্যমে শেয়ার করুন</string>
     <string name="cleaner_recommends">ক্লিনার সুপারিশ করে</string>
     <string name="image_optimizer_card_title">ইমেজ অপটিমাইজার</string>
     <string name="image_optimizer_card_subtitle">গুণগত মান না হারিয়ে ছবি কম্প্রেস করুন.&#10;এক ট্যাপে জায়গা বাঁচান।</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -152,6 +152,12 @@
     <string name="clipboard_current_format">Aktuelle Zwischenablage: %1$s</string>
     <string name="clean_clipboard">Zwischenablage leeren</string>
     <string name="clipboard_cleaned">Die Zwischenablage wurde gereinigt</string>
+    <string name="link_cleaner">Link-Reiniger</string>
+    <string name="link_cleaned">Link bereinigt</string>
+    <string name="link_cleaner_card_title">Link-Reiniger</string>
+    <string name="link_cleaner_card_subtitle">Entfernt Tracking-Parameter aus Links</string>
+    <string name="clean_link">Link bereinigen</string>
+    <string name="share_via">Teilen über</string>
     <string name="cleaner_recommends">Cleaner empfiehlt</string>
     <string name="image_optimizer_card_title">Bildoptimierer</string>
     <string name="image_optimizer_card_subtitle">Fotos ohne Qualitätsverlust komprimieren.&#10;Mit einem Tipp Speicher sparen.</string>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -155,6 +155,12 @@
     <string name="clipboard_current_format">Portapapeles actual: %1$s</string>
     <string name="clean_clipboard">Borrar portapapeles</string>
     <string name="clipboard_cleaned">El portapapeles ha sido limpiado</string>
+    <string name="link_cleaner">Limpiador de enlaces</string>
+    <string name="link_cleaned">Enlace limpiado</string>
+    <string name="link_cleaner_card_title">Limpiador de enlaces</string>
+    <string name="link_cleaner_card_subtitle">Elimina los parámetros de seguimiento de los enlaces</string>
+    <string name="clean_link">Limpiar enlace</string>
+    <string name="share_via">Compartir vía</string>
     <string name="cleaner_recommends">Cleaner recomienda</string>
     <string name="image_optimizer_card_title">Optimizador de imágenes</string>
     <string name="image_optimizer_card_subtitle">Comprime fotos sin perder calidad.&#10;Ahorra espacio con un toque.</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -155,6 +155,12 @@
     <string name="clipboard_current_format">Portapapeles actual: %1$s</string>
     <string name="clean_clipboard">Borrar portapapeles</string>
     <string name="clipboard_cleaned">El portapapeles ha sido limpiado</string>
+    <string name="link_cleaner">Limpiador de enlaces</string>
+    <string name="link_cleaned">Enlace limpiado</string>
+    <string name="link_cleaner_card_title">Limpiador de enlaces</string>
+    <string name="link_cleaner_card_subtitle">Elimina los parámetros de seguimiento de los enlaces</string>
+    <string name="clean_link">Limpiar enlace</string>
+    <string name="share_via">Compartir vía</string>
     <string name="cleaner_recommends">Cleaner recomienda</string>
     <string name="image_optimizer_card_title">Optimizador de imágenes</string>
     <string name="image_optimizer_card_subtitle">Comprime fotos sin perder calidad.&#10;Ahorra espacio con un toque.</string>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -152,6 +152,12 @@
     <string name="clipboard_current_format">Kasalukuyang clipboard: %1$s</string>
     <string name="clean_clipboard">I-clear ang Clipboard</string>
     <string name="clipboard_cleaned">Ang clipboard ay nalinis</string>
+    <string name="link_cleaner">Tagalinis ng Link</string>
+    <string name="link_cleaned">Nalinis ang link</string>
+    <string name="link_cleaner_card_title">Tagalinis ng Link</string>
+    <string name="link_cleaner_card_subtitle">Alisin ang mga tracking parameter sa mga link</string>
+    <string name="clean_link">Linisin ang Link</string>
+    <string name="share_via">Ibahagi sa pamamagitan ng</string>
     <string name="cleaner_recommends">Inirerekomenda ng Cleaner</string>
     <string name="image_optimizer_card_title">Tagapag-optimize ng Larawan</string>
     <string name="image_optimizer_card_subtitle">I-compress ang mga larawan nang hindi nawawala ang kalidad.&#10;Magtipid ng puwang sa isang tap.</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -155,6 +155,12 @@
     <string name="clipboard_current_format">Presse-papiers actuel : %1$s</string>
     <string name="clean_clipboard">Effacer le presse-papiers</string>
     <string name="clipboard_cleaned">Le presse-papiers a été nettoyé</string>
+    <string name="link_cleaner">Nettoyeur de liens</string>
+    <string name="link_cleaned">Lien nettoyé</string>
+    <string name="link_cleaner_card_title">Nettoyeur de liens</string>
+    <string name="link_cleaner_card_subtitle">Supprimez les paramètres de suivi des liens</string>
+    <string name="clean_link">Nettoyer le lien</string>
+    <string name="share_via">Partager via</string>
     <string name="cleaner_recommends">Recommandations de Cleaner</string>
     <string name="image_optimizer_card_title">Optimiseur d’images</string>
     <string name="image_optimizer_card_subtitle">Compressez les photos sans perte de qualité.&#10;Gagnez de la place en un geste.</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -152,6 +152,12 @@
     <string name="clipboard_current_format">वर्तमान क्लिपबोर्ड: %1$s</string>
     <string name="clean_clipboard">क्लिपबोर्ड साफ़ करें</string>
     <string name="clipboard_cleaned">क्लिपबोर्ड को साफ किया गया है</string>
+    <string name="link_cleaner">लिंक क्लीनर</string>
+    <string name="link_cleaned">लिंक साफ़ किया गया</string>
+    <string name="link_cleaner_card_title">लिंक क्लीनर</string>
+    <string name="link_cleaner_card_subtitle">लिंक से ट्रैकिंग पैरामीटर हटाएँ</string>
+    <string name="clean_link">लिंक साफ़ करें</string>
+    <string name="share_via">इसके माध्यम से साझा करें</string>
     <string name="cleaner_recommends">क्लीनर की सिफारिशें</string>
     <string name="image_optimizer_card_title">इमेज ऑप्टिमाइज़र</string>
     <string name="image_optimizer_card_subtitle">गुणवत्ता खोए बिना फोटो कंप्रेस करें।&#10;एक टैप में जगह बचाएं।</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -152,6 +152,12 @@
     <string name="clipboard_current_format">Aktuális vágólap: %1$s</string>
     <string name="clean_clipboard">Vágólap törlése</string>
     <string name="clipboard_cleaned">A vágólapot megtisztították</string>
+    <string name="link_cleaner">Linktisztító</string>
+    <string name="link_cleaned">A linket megtisztították</string>
+    <string name="link_cleaner_card_title">Linktisztító</string>
+    <string name="link_cleaner_card_subtitle">Távolítsa el a követőparamétereket a linkekből</string>
+    <string name="clean_link">Link tisztítása</string>
+    <string name="share_via">Megosztás ezzel</string>
     <string name="cleaner_recommends">A Cleaner ajánlja</string>
     <string name="image_optimizer_card_title">Képoptimalizáló</string>
     <string name="image_optimizer_card_subtitle">Tömörítsd a fotókat minőségromlás nélkül.&#10;Takaríts meg helyet egyetlen érintéssel.</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -149,6 +149,12 @@
     <string name="clipboard_current_format">Clipboard saat ini: %1$s</string>
     <string name="clean_clipboard">Bersihkan Clipboard</string>
     <string name="clipboard_cleaned">Clipboard telah dibersihkan</string>
+    <string name="link_cleaner">Pembersih Tautan</string>
+    <string name="link_cleaned">Tautan telah dibersihkan</string>
+    <string name="link_cleaner_card_title">Pembersih Tautan</string>
+    <string name="link_cleaner_card_subtitle">Hapus parameter pelacakan dari tautan</string>
+    <string name="clean_link">Bersihkan Tautan</string>
+    <string name="share_via">Bagikan melalui</string>
     <string name="cleaner_recommends">Rekomendasi Cleaner</string>
     <string name="image_optimizer_card_title">Pengoptimal Gambar</string>
     <string name="image_optimizer_card_subtitle">Kompres foto tanpa mengurangi kualitas.&#10;Hemat ruang dengan satu ketukan.</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -155,6 +155,12 @@
     <string name="clipboard_current_format">Appunti correnti: %1$s</string>
     <string name="clean_clipboard">Cancella appunti</string>
     <string name="clipboard_cleaned">Gli appunti sono stati puliti</string>
+    <string name="link_cleaner">Pulitore link</string>
+    <string name="link_cleaned">Link pulito</string>
+    <string name="link_cleaner_card_title">Pulitore link</string>
+    <string name="link_cleaner_card_subtitle">Rimuovi i parametri di tracciamento dai link</string>
+    <string name="clean_link">Pulisci link</string>
+    <string name="share_via">Condividi tramite</string>
     <string name="cleaner_recommends">Cleaner consiglia</string>
     <string name="image_optimizer_card_title">Ottimizzatore immagini</string>
     <string name="image_optimizer_card_subtitle">Comprimi le foto senza perdere qualità.&#10;Risparmia spazio con un tocco.</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -149,6 +149,12 @@
     <string name="clipboard_current_format">現在のクリップボード: %1$s</string>
     <string name="clean_clipboard">クリップボードを消去</string>
     <string name="clipboard_cleaned">クリップボードが掃除されました</string>
+    <string name="link_cleaner">リンククリーナー</string>
+    <string name="link_cleaned">リンクをクリーンしました</string>
+    <string name="link_cleaner_card_title">リンククリーナー</string>
+    <string name="link_cleaner_card_subtitle">リンクから追跡パラメータを削除</string>
+    <string name="clean_link">リンクをクリーン</string>
+    <string name="share_via">共有方法</string>
     <string name="cleaner_recommends">Cleaner のおすすめ</string>
     <string name="image_optimizer_card_title">画像最適化</string>
     <string name="image_optimizer_card_subtitle">品質を落とさず写真を圧縮。&#10;ワンタップで容量節約。</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -149,6 +149,12 @@
     <string name="clipboard_current_format">현재 클립보드: %1$s</string>
     <string name="clean_clipboard">클립보드 지우기</string>
     <string name="clipboard_cleaned">클립 보드가 청소되었습니다</string>
+    <string name="link_cleaner">링크 클리너</string>
+    <string name="link_cleaned">링크가 정리되었습니다</string>
+    <string name="link_cleaner_card_title">링크 클리너</string>
+    <string name="link_cleaner_card_subtitle">링크에서 추적 파라미터 제거</string>
+    <string name="clean_link">링크 정리</string>
+    <string name="share_via">공유 방법</string>
     <string name="cleaner_recommends">Cleaner 추천</string>
     <string name="image_optimizer_card_title">이미지 최적화</string>
     <string name="image_optimizer_card_subtitle">품질 저하 없이 사진을 압축합니다.&#10;한 번 탭으로 공간을 절약하세요.</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -158,6 +158,12 @@
     <string name="clipboard_current_format">Aktualny schowek: %1$s</string>
     <string name="clean_clipboard">Wyczyść schowek</string>
     <string name="clipboard_cleaned">Schowek został wyczyszczony</string>
+    <string name="link_cleaner">Czyszczenie linków</string>
+    <string name="link_cleaned">Link wyczyszczony</string>
+    <string name="link_cleaner_card_title">Czyszczenie linków</string>
+    <string name="link_cleaner_card_subtitle">Usuń parametry śledzące z linków</string>
+    <string name="clean_link">Wyczyść link</string>
+    <string name="share_via">Udostępnij przez</string>
     <string name="cleaner_recommends">Rekomendacje Cleaner</string>
     <string name="image_optimizer_card_title">Optymalizator obrazów</string>
     <string name="image_optimizer_card_subtitle">Kompresuj zdjęcia bez utraty jakości.&#10;Zaoszczędź miejsce jednym stuknięciem.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -155,6 +155,12 @@
     <string name="clipboard_current_format">Área de transferência atual: %1$s</string>
     <string name="clean_clipboard">Limpar área de transferência</string>
     <string name="clipboard_cleaned">A área de transferência foi limpa</string>
+    <string name="link_cleaner">Limpador de links</string>
+    <string name="link_cleaned">Link limpo</string>
+    <string name="link_cleaner_card_title">Limpador de links</string>
+    <string name="link_cleaner_card_subtitle">Remova parâmetros de rastreamento dos links</string>
+    <string name="clean_link">Limpar link</string>
+    <string name="share_via">Compartilhar via</string>
     <string name="cleaner_recommends">Recomendações do Cleaner</string>
     <string name="image_optimizer_card_title">Otimizador de imagens</string>
     <string name="image_optimizer_card_subtitle">Comprime fotos sem perder qualidade.&#10;Economize espaço com um toque.</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -155,6 +155,12 @@
     <string name="clipboard_current_format">Clipboard curent: %1$s</string>
     <string name="clean_clipboard">Curăță clipboard-ul</string>
     <string name="clipboard_cleaned">Clipboard a fost curățat</string>
+    <string name="link_cleaner">Curățare linkuri</string>
+    <string name="link_cleaned">Link curățat</string>
+    <string name="link_cleaner_card_title">Curățare linkuri</string>
+    <string name="link_cleaner_card_subtitle">Elimină parametrii de tracking din linkuri</string>
+    <string name="clean_link">Curăță linkul</string>
+    <string name="share_via">Distribuie prin</string>
     <string name="cleaner_recommends">Recomandările Cleaner</string>
     <string name="image_optimizer_card_title">Optimizator de imagini</string>
     <string name="image_optimizer_card_subtitle">Comprimă fotografiile fără pierderi de calitate.&#10;Economisește spațiu cu o atingere.</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -158,6 +158,12 @@
     <string name="clipboard_current_format">Текущий буфер: %1$s</string>
     <string name="clean_clipboard">Очистить буфер обмена</string>
     <string name="clipboard_cleaned">Буфер обмена очищен</string>
+    <string name="link_cleaner">Очистка ссылок</string>
+    <string name="link_cleaned">Ссылка очищена</string>
+    <string name="link_cleaner_card_title">Очистка ссылок</string>
+    <string name="link_cleaner_card_subtitle">Удаляет параметры отслеживания из ссылок</string>
+    <string name="clean_link">Очистить ссылку</string>
+    <string name="share_via">Поделиться через</string>
     <string name="cleaner_recommends">Рекомендации Cleaner</string>
     <string name="image_optimizer_card_title">Оптимизация изображений</string>
     <string name="image_optimizer_card_subtitle">Сжимайте фото без потери качества.&#10;Экономьте место одним нажатием.</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -152,6 +152,12 @@
     <string name="clipboard_current_format">Aktuellt urklipp: %1$s</string>
     <string name="clean_clipboard">Rensa urklipp</string>
     <string name="clipboard_cleaned">Urklipp har rengjorts</string>
+    <string name="link_cleaner">Länkrensare</string>
+    <string name="link_cleaned">Länken rensad</string>
+    <string name="link_cleaner_card_title">Länkrensare</string>
+    <string name="link_cleaner_card_subtitle">Ta bort spårningsparametrar från länkar</string>
+    <string name="clean_link">Rensa länk</string>
+    <string name="share_via">Dela via</string>
     <string name="cleaner_recommends">Cleaner rekommenderar</string>
     <string name="image_optimizer_card_title">Bildoptimerare</string>
     <string name="image_optimizer_card_subtitle">Komprimera foton utan kvalitetsförlust.&#10;Spara utrymme med ett tryck.</string>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -149,6 +149,12 @@
     <string name="clipboard_current_format">คลิปบอร์ดปัจจุบัน: %1$s</string>
     <string name="clean_clipboard">ล้างคลิปบอร์ด</string>
     <string name="clipboard_cleaned">คลิปบอร์ดได้รับการทำความสะอาด</string>
+    <string name="link_cleaner">ตัวล้างลิงก์</string>
+    <string name="link_cleaned">ลิงก์ถูกล้างแล้ว</string>
+    <string name="link_cleaner_card_title">ตัวล้างลิงก์</string>
+    <string name="link_cleaner_card_subtitle">ลบพารามิเตอร์ติดตามออกจากลิงก์</string>
+    <string name="clean_link">ล้างลิงก์</string>
+    <string name="share_via">แชร์ผ่าน</string>
     <string name="cleaner_recommends">คำแนะนำจาก Cleaner</string>
     <string name="image_optimizer_card_title">ตัวเพิ่มประสิทธิภาพรูปภาพ</string>
     <string name="image_optimizer_card_subtitle">บีบอัดรูปภาพโดยไม่ลดคุณภาพ&#10;ประหยัดพื้นที่ด้วยการแตะครั้งเดียว</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -152,6 +152,12 @@
     <string name="clipboard_current_format">Geçerli pano: %1$s</string>
     <string name="clean_clipboard">Panoyu Temizle</string>
     <string name="clipboard_cleaned">Pano temizlendi</string>
+    <string name="link_cleaner">Bağlantı Temizleyici</string>
+    <string name="link_cleaned">Bağlantı temizlendi</string>
+    <string name="link_cleaner_card_title">Bağlantı Temizleyici</string>
+    <string name="link_cleaner_card_subtitle">Bağlantılardan izleme parametrelerini kaldırın</string>
+    <string name="clean_link">Bağlantıyı temizle</string>
+    <string name="share_via">Şununla paylaş</string>
     <string name="cleaner_recommends">Cleaner Öneriyor</string>
     <string name="image_optimizer_card_title">Görüntü Optimize Edici</string>
     <string name="image_optimizer_card_subtitle">Fotoğrafları kalite kaybı olmadan sıkıştırın.&#10;Tek dokunuşla yer açın.</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -158,6 +158,12 @@
     <string name="clipboard_current_format">Поточний буфер: %1$s</string>
     <string name="clean_clipboard">Очистити буфер обміну</string>
     <string name="clipboard_cleaned">Буфер обміну був очищений</string>
+    <string name="link_cleaner">Очищувач посилань</string>
+    <string name="link_cleaned">Посилання очищено</string>
+    <string name="link_cleaner_card_title">Очищувач посилань</string>
+    <string name="link_cleaner_card_subtitle">Видаляє параметри відстеження з посилань</string>
+    <string name="clean_link">Очистити посилання</string>
+    <string name="share_via">Поділитися через</string>
     <string name="cleaner_recommends">Рекомендації Cleaner</string>
     <string name="image_optimizer_card_title">Оптимізатор зображень</string>
     <string name="image_optimizer_card_subtitle">Стискайте фото без втрати якості.&#10;Заощаджуйте місце одним дотиком.</string>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -152,6 +152,12 @@
     <string name="clipboard_current_format">موجودہ کلپ بورڈ: %1$s</string>
     <string name="clean_clipboard">کلپ بورڈ صاف کریں</string>
     <string name="clipboard_cleaned">کلپ بورڈ صاف کیا گیا ہے</string>
+    <string name="link_cleaner">لنک کلینر</string>
+    <string name="link_cleaned">لنک صاف ہوگیا</string>
+    <string name="link_cleaner_card_title">لنک کلینر</string>
+    <string name="link_cleaner_card_subtitle">لنکس سے ٹریکنگ پیرا میٹرز ہٹائیں</string>
+    <string name="clean_link">لنک صاف کریں</string>
+    <string name="share_via">کے ذریعے شیئر کریں</string>
     <string name="cleaner_recommends">Cleaner کی سفارشات</string>
     <string name="image_optimizer_card_title">امیج آپٹیمائزر</string>
     <string name="image_optimizer_card_subtitle">بغیر معیار کھوئے تصاویر کمپریس کریں۔&#10;ایک ٹیپ سے جگہ بچائیں۔</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -149,6 +149,12 @@
     <string name="clipboard_current_format">Bảng tạm hiện tại: %1$s</string>
     <string name="clean_clipboard">Xóa bảng tạm</string>
     <string name="clipboard_cleaned">Clipboard đã được làm sạch</string>
+    <string name="link_cleaner">Trình làm sạch liên kết</string>
+    <string name="link_cleaned">Liên kết đã được làm sạch</string>
+    <string name="link_cleaner_card_title">Trình làm sạch liên kết</string>
+    <string name="link_cleaner_card_subtitle">Loại bỏ tham số theo dõi khỏi liên kết</string>
+    <string name="clean_link">Làm sạch liên kết</string>
+    <string name="share_via">Chia sẻ qua</string>
     <string name="cleaner_recommends">Gợi ý từ Cleaner</string>
     <string name="image_optimizer_card_title">Trình tối ưu ảnh</string>
     <string name="image_optimizer_card_subtitle">Nén ảnh mà không giảm chất lượng.&#10;Tiết kiệm dung lượng chỉ với một chạm.</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -149,6 +149,12 @@
     <string name="clipboard_current_format">目前剪貼簿：%1$s</string>
     <string name="clean_clipboard">清除剪貼簿</string>
     <string name="clipboard_cleaned">剪貼板已清潔</string>
+    <string name="link_cleaner">連結清理</string>
+    <string name="link_cleaned">連結已清理</string>
+    <string name="link_cleaner_card_title">連結清理</string>
+    <string name="link_cleaner_card_subtitle">移除連結中的追蹤參數</string>
+    <string name="clean_link">清理連結</string>
+    <string name="share_via">分享方式</string>
     <string name="cleaner_recommends">Cleaner 推薦</string>
     <string name="image_optimizer_card_title">影像最佳化</string>
     <string name="image_optimizer_card_subtitle">壓縮照片而不失去品質。&#10;一鍵釋放空間。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -152,6 +152,12 @@
     <string name="clipboard_current_format">Current clipboard: %1$s</string>
     <string name="clean_clipboard">Clear Clipboard</string>
     <string name="clipboard_cleaned">Clipboard cleaned</string>
+    <string name="link_cleaner">Link Cleaner</string>
+    <string name="link_cleaned">Link cleaned</string>
+    <string name="link_cleaner_card_title">Link Cleaner</string>
+    <string name="link_cleaner_card_subtitle">Remove tracking parameters from links</string>
+    <string name="clean_link">Clean Link</string>
+    <string name="share_via">Share via</string>
     <string name="cleaner_recommends">Cleaner Recommends</string>
     <string name="image_optimizer_card_title">Image Optimizer</string>
     <string name="image_optimizer_card_subtitle">Compress photos without losing quality.&#10;Save space with one tap.</string>


### PR DESCRIPTION
## Summary
- implement URL sanitization in `UrlCleaner`
- add `LinkCleanerActivity` to clean and share URLs
- expose feature via `LinkCleanerCard` on the dashboard
- register new activity in the manifest
- update strings, README, and changelog

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886558845f4832db3d9baac2000f75c