### PR TITLE
Add clipboard paste to LinkCleaner card

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/dashboard/ui/ScannerDashboardScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/dashboard/ui/ScannerDashboardScreen.kt
@@ -389,12 +389,6 @@ fun ScannerDashboardScreen(
                             index = linkIndex
                         )
                         .animateContentSize(),
-                    linkText = null,
-                    onCleanClick = {
-                        IntentsHelper.openActivity(
-                            context = context, activityClass = LinkCleanerActivity::class.java
-                        )
-                    }
                 )
             }
         }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/LinkCleanerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/LinkCleanerCard.kt
@@ -1,6 +1,5 @@
 package com.d4rk.cleaner.app.clean.scanner.ui.components
 
-import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -8,28 +7,39 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import android.content.Intent
+import androidx.compose.material.icons.outlined.ContentPaste
 import androidx.compose.material.icons.outlined.Link
 import androidx.compose.material.icons.outlined.LinkOff
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextOverflow
 import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.TonalIconButtonWithText
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.SmallVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.cleaner.R
+import com.d4rk.cleaner.app.clean.link.ui.LinkCleanerActivity
 
 @Composable
 fun LinkCleanerCard(
-    linkText: String?,
     modifier: Modifier = Modifier,
-    onCleanClick: () -> Unit,
 ) {
+    var linkText by rememberSaveable { mutableStateOf("") }
+    val clipboardManager = LocalClipboardManager.current
+    val context = LocalContext.current
     OutlinedCard(
         modifier = modifier.fillMaxWidth(),
         shape = RoundedCornerShape(SizeConstants.ExtraLargeSize),
@@ -59,15 +69,24 @@ fun LinkCleanerCard(
                 }
             }
 
-            linkText?.let { text ->
-                Text(
-                    text = text,
-                    style = MaterialTheme.typography.bodyMedium,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.animateContentSize()
-                )
-            }
+            OutlinedTextField(
+                value = linkText,
+                onValueChange = { linkText = it },
+                label = { Text(text = stringResource(id = R.string.link)) },
+                singleLine = true,
+                trailingIcon = {
+                    IconButton(onClick = {
+                        val text = clipboardManager.getText()?.text?.toString()?.trim()
+                        if (!text.isNullOrEmpty()) linkText = text
+                    }) {
+                        Icon(
+                            imageVector = Icons.Outlined.ContentPaste,
+                            contentDescription = stringResource(id = R.string.paste_from_clipboard)
+                        )
+                    }
+                },
+                modifier = Modifier.fillMaxWidth()
+            )
 
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -76,7 +95,13 @@ fun LinkCleanerCard(
                 TonalIconButtonWithText(
                     label = stringResource(id = R.string.clean_link),
                     icon = Icons.Outlined.LinkOff,
-                    onClick = onCleanClick,
+                    enabled = linkText.isNotBlank(),
+                    onClick = {
+                        val intent = Intent(context, LinkCleanerActivity::class.java).apply {
+                            putExtra(Intent.EXTRA_TEXT, linkText)
+                        }
+                        context.startActivity(intent)
+                    },
                 )
             }
         }

--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -168,6 +168,8 @@
     <string name="link_cleaned">تم تنظيف الرابط</string>
     <string name="link_cleaner_card_title">منظف الروابط</string>
     <string name="link_cleaner_card_subtitle">إزالة معلمات التتبع من الروابط</string>
+    <string name="link">رابط</string>
+    <string name="paste_from_clipboard">لصق</string>
     <string name="clean_link">تنظيف الرابط</string>
     <string name="share_via">مشاركة عبر</string>
     <string name="cleaner_recommends">يوصي Cleaner</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -156,6 +156,8 @@
     <string name="link_cleaned">Връзката е почистена</string>
     <string name="link_cleaner_card_title">Почистващ връзки</string>
     <string name="link_cleaner_card_subtitle">Премахнете проследяващите параметри от връзките</string>
+    <string name="link">Връзка</string>
+    <string name="paste_from_clipboard">Поставяне</string>
     <string name="clean_link">Почисти връзката</string>
     <string name="share_via">Сподели чрез</string>
     <string name="cleaner_recommends">Cleaner препоръчва</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -156,6 +156,8 @@
     <string name="link_cleaned">লিঙ্ক পরিষ্কার হয়েছে</string>
     <string name="link_cleaner_card_title">লিঙ্ক ক্লিনার</string>
     <string name="link_cleaner_card_subtitle">লিঙ্ক থেকে ট্র্যাকিং প্যারামিটার সরান</string>
+    <string name="link">লিঙ্ক</string>
+    <string name="paste_from_clipboard">পেস্ট</string>
     <string name="clean_link">লিঙ্ক পরিষ্কার করুন</string>
     <string name="share_via">মাধ্যমে শেয়ার করুন</string>
     <string name="cleaner_recommends">ক্লিনার সুপারিশ করে</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -156,6 +156,8 @@
     <string name="link_cleaned">Link bereinigt</string>
     <string name="link_cleaner_card_title">Link-Reiniger</string>
     <string name="link_cleaner_card_subtitle">Entfernt Tracking-Parameter aus Links</string>
+    <string name="link">Link</string>
+    <string name="paste_from_clipboard">Einfügen</string>
     <string name="clean_link">Link bereinigen</string>
     <string name="share_via">Teilen über</string>
     <string name="cleaner_recommends">Cleaner empfiehlt</string>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -159,6 +159,8 @@
     <string name="link_cleaned">Enlace limpiado</string>
     <string name="link_cleaner_card_title">Limpiador de enlaces</string>
     <string name="link_cleaner_card_subtitle">Elimina los parámetros de seguimiento de los enlaces</string>
+    <string name="link">Enlace</string>
+    <string name="paste_from_clipboard">Pegar</string>
     <string name="clean_link">Limpiar enlace</string>
     <string name="share_via">Compartir vía</string>
     <string name="cleaner_recommends">Cleaner recomienda</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -159,6 +159,8 @@
     <string name="link_cleaned">Enlace limpiado</string>
     <string name="link_cleaner_card_title">Limpiador de enlaces</string>
     <string name="link_cleaner_card_subtitle">Elimina los parámetros de seguimiento de los enlaces</string>
+    <string name="link">Enlace</string>
+    <string name="paste_from_clipboard">Pegar</string>
     <string name="clean_link">Limpiar enlace</string>
     <string name="share_via">Compartir vía</string>
     <string name="cleaner_recommends">Cleaner recomienda</string>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -156,6 +156,8 @@
     <string name="link_cleaned">Nalinis ang link</string>
     <string name="link_cleaner_card_title">Tagalinis ng Link</string>
     <string name="link_cleaner_card_subtitle">Alisin ang mga tracking parameter sa mga link</string>
+    <string name="link">Link</string>
+    <string name="paste_from_clipboard">I-paste</string>
     <string name="clean_link">Linisin ang Link</string>
     <string name="share_via">Ibahagi sa pamamagitan ng</string>
     <string name="cleaner_recommends">Inirerekomenda ng Cleaner</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -159,6 +159,8 @@
     <string name="link_cleaned">Lien nettoyé</string>
     <string name="link_cleaner_card_title">Nettoyeur de liens</string>
     <string name="link_cleaner_card_subtitle">Supprimez les paramètres de suivi des liens</string>
+    <string name="link">Lien</string>
+    <string name="paste_from_clipboard">Coller</string>
     <string name="clean_link">Nettoyer le lien</string>
     <string name="share_via">Partager via</string>
     <string name="cleaner_recommends">Recommandations de Cleaner</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -156,6 +156,8 @@
     <string name="link_cleaned">लिंक साफ़ किया गया</string>
     <string name="link_cleaner_card_title">लिंक क्लीनर</string>
     <string name="link_cleaner_card_subtitle">लिंक से ट्रैकिंग पैरामीटर हटाएँ</string>
+    <string name="link">लिंक</string>
+    <string name="paste_from_clipboard">पेस्ट</string>
     <string name="clean_link">लिंक साफ़ करें</string>
     <string name="share_via">इसके माध्यम से साझा करें</string>
     <string name="cleaner_recommends">क्लीनर की सिफारिशें</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -156,6 +156,8 @@
     <string name="link_cleaned">A linket megtisztították</string>
     <string name="link_cleaner_card_title">Linktisztító</string>
     <string name="link_cleaner_card_subtitle">Távolítsa el a követőparamétereket a linkekből</string>
+    <string name="link">Link</string>
+    <string name="paste_from_clipboard">Beillesztés</string>
     <string name="clean_link">Link tisztítása</string>
     <string name="share_via">Megosztás ezzel</string>
     <string name="cleaner_recommends">A Cleaner ajánlja</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -153,6 +153,8 @@
     <string name="link_cleaned">Tautan telah dibersihkan</string>
     <string name="link_cleaner_card_title">Pembersih Tautan</string>
     <string name="link_cleaner_card_subtitle">Hapus parameter pelacakan dari tautan</string>
+    <string name="link">Tautan</string>
+    <string name="paste_from_clipboard">Tempel</string>
     <string name="clean_link">Bersihkan Tautan</string>
     <string name="share_via">Bagikan melalui</string>
     <string name="cleaner_recommends">Rekomendasi Cleaner</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -159,6 +159,8 @@
     <string name="link_cleaned">Link pulito</string>
     <string name="link_cleaner_card_title">Pulitore link</string>
     <string name="link_cleaner_card_subtitle">Rimuovi i parametri di tracciamento dai link</string>
+    <string name="link">Link</string>
+    <string name="paste_from_clipboard">Incolla</string>
     <string name="clean_link">Pulisci link</string>
     <string name="share_via">Condividi tramite</string>
     <string name="cleaner_recommends">Cleaner consiglia</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -153,6 +153,8 @@
     <string name="link_cleaned">リンクをクリーンしました</string>
     <string name="link_cleaner_card_title">リンククリーナー</string>
     <string name="link_cleaner_card_subtitle">リンクから追跡パラメータを削除</string>
+    <string name="link">リンク</string>
+    <string name="paste_from_clipboard">貼り付け</string>
     <string name="clean_link">リンクをクリーン</string>
     <string name="share_via">共有方法</string>
     <string name="cleaner_recommends">Cleaner のおすすめ</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -153,6 +153,8 @@
     <string name="link_cleaned">링크가 정리되었습니다</string>
     <string name="link_cleaner_card_title">링크 클리너</string>
     <string name="link_cleaner_card_subtitle">링크에서 추적 파라미터 제거</string>
+    <string name="link">링크</string>
+    <string name="paste_from_clipboard">붙여넣기</string>
     <string name="clean_link">링크 정리</string>
     <string name="share_via">공유 방법</string>
     <string name="cleaner_recommends">Cleaner 추천</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -162,6 +162,8 @@
     <string name="link_cleaned">Link wyczyszczony</string>
     <string name="link_cleaner_card_title">Czyszczenie linków</string>
     <string name="link_cleaner_card_subtitle">Usuń parametry śledzące z linków</string>
+    <string name="link">Link</string>
+    <string name="paste_from_clipboard">Wklej</string>
     <string name="clean_link">Wyczyść link</string>
     <string name="share_via">Udostępnij przez</string>
     <string name="cleaner_recommends">Rekomendacje Cleaner</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -159,6 +159,8 @@
     <string name="link_cleaned">Link limpo</string>
     <string name="link_cleaner_card_title">Limpador de links</string>
     <string name="link_cleaner_card_subtitle">Remova parâmetros de rastreamento dos links</string>
+    <string name="link">Link</string>
+    <string name="paste_from_clipboard">Colar</string>
     <string name="clean_link">Limpar link</string>
     <string name="share_via">Compartilhar via</string>
     <string name="cleaner_recommends">Recomendações do Cleaner</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -159,6 +159,8 @@
     <string name="link_cleaned">Link curățat</string>
     <string name="link_cleaner_card_title">Curățare linkuri</string>
     <string name="link_cleaner_card_subtitle">Elimină parametrii de tracking din linkuri</string>
+    <string name="link">Link</string>
+    <string name="paste_from_clipboard">Lipește</string>
     <string name="clean_link">Curăță linkul</string>
     <string name="share_via">Distribuie prin</string>
     <string name="cleaner_recommends">Recomandările Cleaner</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -162,6 +162,8 @@
     <string name="link_cleaned">Ссылка очищена</string>
     <string name="link_cleaner_card_title">Очистка ссылок</string>
     <string name="link_cleaner_card_subtitle">Удаляет параметры отслеживания из ссылок</string>
+    <string name="link">Ссылка</string>
+    <string name="paste_from_clipboard">Вставить</string>
     <string name="clean_link">Очистить ссылку</string>
     <string name="share_via">Поделиться через</string>
     <string name="cleaner_recommends">Рекомендации Cleaner</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -156,6 +156,8 @@
     <string name="link_cleaned">Länken rensad</string>
     <string name="link_cleaner_card_title">Länkrensare</string>
     <string name="link_cleaner_card_subtitle">Ta bort spårningsparametrar från länkar</string>
+    <string name="link">Länk</string>
+    <string name="paste_from_clipboard">Klistra in</string>
     <string name="clean_link">Rensa länk</string>
     <string name="share_via">Dela via</string>
     <string name="cleaner_recommends">Cleaner rekommenderar</string>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -153,6 +153,8 @@
     <string name="link_cleaned">ลิงก์ถูกล้างแล้ว</string>
     <string name="link_cleaner_card_title">ตัวล้างลิงก์</string>
     <string name="link_cleaner_card_subtitle">ลบพารามิเตอร์ติดตามออกจากลิงก์</string>
+    <string name="link">ลิงก์</string>
+    <string name="paste_from_clipboard">วาง</string>
     <string name="clean_link">ล้างลิงก์</string>
     <string name="share_via">แชร์ผ่าน</string>
     <string name="cleaner_recommends">คำแนะนำจาก Cleaner</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -156,6 +156,8 @@
     <string name="link_cleaned">Bağlantı temizlendi</string>
     <string name="link_cleaner_card_title">Bağlantı Temizleyici</string>
     <string name="link_cleaner_card_subtitle">Bağlantılardan izleme parametrelerini kaldırın</string>
+    <string name="link">Bağlantı</string>
+    <string name="paste_from_clipboard">Yapıştır</string>
     <string name="clean_link">Bağlantıyı temizle</string>
     <string name="share_via">Şununla paylaş</string>
     <string name="cleaner_recommends">Cleaner Öneriyor</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -162,6 +162,8 @@
     <string name="link_cleaned">Посилання очищено</string>
     <string name="link_cleaner_card_title">Очищувач посилань</string>
     <string name="link_cleaner_card_subtitle">Видаляє параметри відстеження з посилань</string>
+    <string name="link">Посилання</string>
+    <string name="paste_from_clipboard">Вставити</string>
     <string name="clean_link">Очистити посилання</string>
     <string name="share_via">Поділитися через</string>
     <string name="cleaner_recommends">Рекомендації Cleaner</string>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -156,6 +156,8 @@
     <string name="link_cleaned">لنک صاف ہوگیا</string>
     <string name="link_cleaner_card_title">لنک کلینر</string>
     <string name="link_cleaner_card_subtitle">لنکس سے ٹریکنگ پیرا میٹرز ہٹائیں</string>
+    <string name="link">لنک</string>
+    <string name="paste_from_clipboard">پیسٹ کریں</string>
     <string name="clean_link">لنک صاف کریں</string>
     <string name="share_via">کے ذریعے شیئر کریں</string>
     <string name="cleaner_recommends">Cleaner کی سفارشات</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -153,6 +153,8 @@
     <string name="link_cleaned">Liên kết đã được làm sạch</string>
     <string name="link_cleaner_card_title">Trình làm sạch liên kết</string>
     <string name="link_cleaner_card_subtitle">Loại bỏ tham số theo dõi khỏi liên kết</string>
+    <string name="link">Liên kết</string>
+    <string name="paste_from_clipboard">Dán</string>
     <string name="clean_link">Làm sạch liên kết</string>
     <string name="share_via">Chia sẻ qua</string>
     <string name="cleaner_recommends">Gợi ý từ Cleaner</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -153,6 +153,8 @@
     <string name="link_cleaned">連結已清理</string>
     <string name="link_cleaner_card_title">連結清理</string>
     <string name="link_cleaner_card_subtitle">移除連結中的追蹤參數</string>
+    <string name="link">連結</string>
+    <string name="paste_from_clipboard">貼上</string>
     <string name="clean_link">清理連結</string>
     <string name="share_via">分享方式</string>
     <string name="cleaner_recommends">Cleaner 推薦</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -156,7 +156,9 @@
     <string name="link_cleaned">Link cleaned</string>
     <string name="link_cleaner_card_title">Link Cleaner</string>
     <string name="link_cleaner_card_subtitle">Remove tracking parameters from links</string>
+    <string name="link">Link</string>
     <string name="clean_link">Clean Link</string>
+    <string name="paste_from_clipboard">Paste</string>
     <string name="share_via">Share via</string>
     <string name="cleaner_recommends">Cleaner Recommends</string>
     <string name="image_optimizer_card_title">Image Optimizer</string>


### PR DESCRIPTION
## Summary
- allow entering/pasting a link directly in the LinkCleaner card
- disable the clean button when no link is entered
- open the cleaner activity with the typed link
- update dashboard to use new LinkCleaner card API
- add new string resources for the UI

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68866dd5d7f4832da5401994bdfbf2a3