### PR TITLE
Enable LinkCleaner button only for valid links

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/LinkCleanerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/LinkCleanerCard.kt
@@ -33,6 +33,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.SmallVertical
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.cleaner.R
 import com.d4rk.cleaner.app.clean.link.ui.LinkCleanerActivity
+import com.d4rk.cleaner.core.utils.extensions.isValidUrl
 import kotlinx.coroutines.launch
 
 @Composable
@@ -105,7 +106,7 @@ fun LinkCleanerCard(
                 TonalIconButtonWithText(
                     label = stringResource(id = R.string.clean_link),
                     icon = Icons.Outlined.LinkOff,
-                    enabled = linkText.isNotBlank(),
+                    enabled = linkText.isValidUrl(),
                     onClick = {
                         val intent = Intent(context, LinkCleanerActivity::class.java).apply {
                             putExtra(Intent.EXTRA_TEXT, linkText)

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/extensions/UrlExtensions.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/extensions/UrlExtensions.kt
@@ -1,0 +1,7 @@
+package com.d4rk.cleaner.core.utils.extensions
+
+import androidx.core.util.PatternsCompat
+
+fun String.isValidUrl(): Boolean {
+    return PatternsCompat.WEB_URL.matcher(this.trim()).matches()
+}


### PR DESCRIPTION
## Summary
- add `isValidUrl` extension using `PatternsCompat.WEB_URL`
- enable LinkCleaner button when input is a valid URL

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688674fe8404832d835d82ff47efa9c5