### PR TITLE
Refactor cleanup activities

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/ui/ContactsCleanerActivity.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/ui/ContactsCleanerActivity.kt
@@ -1,28 +1,12 @@
 package com.d4rk.cleaner.app.clean.contacts.ui
 
 import android.os.Bundle
-import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.ui.Modifier
-import com.d4rk.android.libs.apptoolkit.app.theme.style.AppTheme
+import androidx.compose.runtime.Composable
+import com.d4rk.cleaner.core.ui.BaseCleanupActivity
 
-class ContactsCleanerActivity : AppCompatActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
-        setContent {
-            AppTheme {
-                Surface(
-                    modifier = Modifier.fillMaxSize(),
-                    color = MaterialTheme.colorScheme.background
-                ) {
-                    ContactsCleanerScreen(activity = this@ContactsCleanerActivity)
-                }
-            }
-        }
+class ContactsCleanerActivity : BaseCleanupActivity() {
+    @Composable
+    override fun ScreenContent() {
+        ContactsCleanerScreen(activity = this@ContactsCleanerActivity)
     }
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/largefiles/ui/LargeFilesActivity.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/largefiles/ui/LargeFilesActivity.kt
@@ -1,28 +1,12 @@
 package com.d4rk.cleaner.app.clean.largefiles.ui
 
 import android.os.Bundle
-import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.ui.Modifier
-import com.d4rk.android.libs.apptoolkit.app.theme.style.AppTheme
+import androidx.compose.runtime.Composable
+import com.d4rk.cleaner.core.ui.BaseCleanupActivity
 
-class LargeFilesActivity : AppCompatActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
-        setContent {
-            AppTheme {
-                Surface(
-                    modifier = Modifier.fillMaxSize(),
-                    color = MaterialTheme.colorScheme.background
-                ) {
-                    LargeFilesScreen(activity = this@LargeFilesActivity)
-                }
-            }
-        }
+class LargeFilesActivity : BaseCleanupActivity() {
+    @Composable
+    override fun ScreenContent() {
+        LargeFilesScreen(activity = this@LargeFilesActivity)
     }
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/trash/ui/TrashActivity.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/trash/ui/TrashActivity.kt
@@ -1,29 +1,13 @@
 package com.d4rk.cleaner.app.clean.trash.ui
 
 import android.os.Bundle
-import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.ui.Modifier
-import com.d4rk.android.libs.apptoolkit.app.theme.style.AppTheme
+import androidx.compose.runtime.Composable
+import com.d4rk.cleaner.core.ui.BaseCleanupActivity
 
-class TrashActivity : AppCompatActivity() {
+class TrashActivity : BaseCleanupActivity() {
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
-
-        setContent {
-            AppTheme {
-                Surface(
-                    modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background
-                ) {
-                    TrashScreen(activity = this@TrashActivity)
-                }
-            }
-        }
+    @Composable
+    override fun ScreenContent() {
+        TrashScreen(activity = this@TrashActivity)
     }
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/WhatsAppDetailsActivity.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/WhatsAppDetailsActivity.kt
@@ -1,19 +1,13 @@
 package com.d4rk.cleaner.app.clean.whatsapp.details.ui
 
 import android.os.Bundle
-import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.ui.Modifier
-import com.d4rk.android.libs.apptoolkit.app.theme.style.AppTheme
+import androidx.compose.runtime.Composable
+import com.d4rk.cleaner.core.ui.BaseCleanupActivity
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.actions.WhatsAppCleanerEvent
 import com.d4rk.cleaner.app.clean.whatsapp.summary.ui.WhatsappCleanerSummaryViewModel
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
-class WhatsAppDetailsActivity : AppCompatActivity() {
+class WhatsAppDetailsActivity : BaseCleanupActivity() {
 
     companion object {
         const val EXTRA_TYPE = "type"
@@ -21,26 +15,21 @@ class WhatsAppDetailsActivity : AppCompatActivity() {
 
     private val viewModel: WhatsappCleanerSummaryViewModel by viewModel()
     private val detailsViewModel: DetailsViewModel by viewModel()
+    private var type: String = ""
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        type = intent.getStringExtra(EXTRA_TYPE) ?: ""
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
-        val type = intent.getStringExtra(EXTRA_TYPE) ?: ""
-        setContent {
-            AppTheme {
-                Surface(
-                    modifier = Modifier.fillMaxSize(),
-                    color = MaterialTheme.colorScheme.background
-                ) {
-                    DetailsScreen(
-                        viewModel = viewModel,
-                        detailsViewModel = detailsViewModel,
-                        title = type,
-                        onDelete = { viewModel.onEvent(WhatsAppCleanerEvent.DeleteSelected(it)) },
-                        activity = this
-                    )
-                }
-            }
-        }
+    }
+
+    @Composable
+    override fun ScreenContent() {
+        DetailsScreen(
+            viewModel = viewModel,
+            detailsViewModel = detailsViewModel,
+            title = type,
+            onDelete = { viewModel.onEvent(WhatsAppCleanerEvent.DeleteSelected(it)) },
+            activity = this
+        )
     }
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsAppCleanerSummaryActivity.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsAppCleanerSummaryActivity.kt
@@ -1,28 +1,11 @@
 package com.d4rk.cleaner.app.clean.whatsapp.summary.ui
 
-import android.os.Bundle
-import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.ui.Modifier
-import com.d4rk.android.libs.apptoolkit.app.theme.style.AppTheme
+import androidx.compose.runtime.Composable
+import com.d4rk.cleaner.core.ui.BaseCleanupActivity
 
-class WhatsAppCleanerActivity : AppCompatActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
-        setContent {
-            AppTheme {
-                Surface(
-                    modifier = Modifier.fillMaxSize(),
-                    color = MaterialTheme.colorScheme.background
-                ) {
-                    WhatsappCleanerSummaryScreen(activity = this)
-                }
-            }
-        }
+class WhatsAppCleanerActivity : BaseCleanupActivity() {
+    @Composable
+    override fun ScreenContent() {
+        WhatsappCleanerSummaryScreen(activity = this)
     }
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/images/compressor/ui/ImageOptimizerActivity.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/images/compressor/ui/ImageOptimizerActivity.kt
@@ -1,40 +1,31 @@
 package com.d4rk.cleaner.app.images.compressor.ui
 
 import android.os.Bundle
-import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.ui.Modifier
+import androidx.compose.runtime.Composable
 import androidx.core.net.toUri
 import androidx.lifecycle.lifecycleScope
-import com.d4rk.android.libs.apptoolkit.app.theme.style.AppTheme
+import com.d4rk.cleaner.core.ui.BaseCleanupActivity
 import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
-class ImageOptimizerActivity : AppCompatActivity() {
+class ImageOptimizerActivity : BaseCleanupActivity() {
     private val viewModel: ImageOptimizerViewModel by viewModel()
 
+    private var selectedImageUriString: String? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
-        val selectedImageUriString: String? = intent.getStringExtra("selectedImageUri")
+        selectedImageUriString = intent.getStringExtra("selectedImageUri")
         if (!selectedImageUriString.isNullOrEmpty()) {
             lifecycleScope.launch {
-                viewModel.onImageSelected(selectedImageUriString.toUri())
+                viewModel.onImageSelected(selectedImageUriString!!.toUri())
             }
         }
+        super.onCreate(savedInstanceState)
+    }
 
-        setContent {
-            AppTheme {
-                Surface(
-                    modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background
-                ) {
-                    ImageOptimizerScreen(activity = this@ImageOptimizerActivity, viewModel)
-                }
-            }
-        }
+    @Composable
+    override fun ScreenContent() {
+        ImageOptimizerScreen(activity = this@ImageOptimizerActivity, viewModel)
     }
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/images/picker/ui/ImagePickerActivity.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/images/picker/ui/ImagePickerActivity.kt
@@ -1,19 +1,14 @@
 package com.d4rk.cleaner.app.images.picker.ui
 
 import android.os.Bundle
-import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
-import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.ui.Modifier
-import com.d4rk.android.libs.apptoolkit.app.theme.style.AppTheme
+import androidx.compose.runtime.Composable
+import com.d4rk.cleaner.core.ui.BaseCleanupActivity
 
-class ImagePickerActivity : AppCompatActivity() {
+class ImagePickerActivity : BaseCleanupActivity() {
     private val viewModel: ImagePickerViewModel by viewModels()
 
     private val pickMediaLauncher =
@@ -23,17 +18,12 @@ class ImagePickerActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
-        setContent {
-            AppTheme {
-                Surface(
-                    modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background
-                ) {
-                    ImagePickerComposable(activity = this@ImagePickerActivity, viewModel)
-                }
-            }
-        }
         selectImage()
+    }
+
+    @Composable
+    override fun ScreenContent() {
+        ImagePickerComposable(activity = this@ImagePickerActivity, viewModel)
     }
 
     fun selectImage() {

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/ui/BaseCleanupActivity.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/ui/BaseCleanupActivity.kt
@@ -1,0 +1,39 @@
+package com.d4rk.cleaner.core.ui
+
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.d4rk.android.libs.apptoolkit.app.theme.style.AppTheme
+
+/**
+ * Activity that provides common Compose setup for cleanup screens.
+ */
+abstract class BaseCleanupActivity : AppCompatActivity() {
+
+    /**
+     * Compose content to be rendered by this activity.
+     */
+    @Composable
+    protected abstract fun ScreenContent()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContent {
+            AppTheme {
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.background
+                ) {
+                    ScreenContent()
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `BaseCleanupActivity` that sets up Compose for cleanup screens
- refactor existing cleanup activities to extend the new base
- simplify onCreate implementations and remove boilerplate

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688688f12468832da7065dd7ed26773e