### PR TITLE
Refactor scanning API to stream files

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/domain/interface/ScannerRepositoryInterface.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/domain/interface/ScannerRepositoryInterface.kt
@@ -3,12 +3,13 @@ package com.d4rk.cleaner.app.clean.scanner.domain.`interface`
 import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.FileTypesData
 import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.UiScannerModel
 import java.io.File
+import kotlinx.coroutines.flow.Flow
 
 interface ScannerRepositoryInterface {
     suspend fun getStorageInfo(): UiScannerModel
     suspend fun getFileTypes(): FileTypesData
-    suspend fun getAllFiles(): Pair<List<File>, List<File>>
-    suspend fun getEmptyFolders(): List<File>
+    fun getAllFiles(): Flow<File>
+    fun getEmptyFolders(): Flow<File>
     suspend fun getTrashFiles(): List<File>
     suspend fun getLargestFiles(limit: Int): List<File>
     suspend fun deleteFiles(filesToDelete: Set<File>)

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/domain/usecases/GetEmptyFoldersUseCase.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/domain/usecases/GetEmptyFoldersUseCase.kt
@@ -10,12 +10,12 @@ import kotlinx.coroutines.flow.flow
 import java.io.File
 
 class GetEmptyFoldersUseCase(private val repository: ScannerRepositoryInterface) {
-    operator fun invoke(): Flow<DataState<List<File>, Errors>> = flow {
+    operator fun invoke(): Flow<DataState<File, Errors>> = flow {
         emit(DataState.Loading())
         runCatching {
-            repository.getEmptyFolders()
-        }.onSuccess { folders ->
-            emit(DataState.Success(folders))
+            repository.getEmptyFolders().collect { folder ->
+                emit(DataState.Success(folder))
+            }
         }.onFailure { throwable ->
             if (throwable is CancellationException) throw throwable
             emit(DataState.Error(error = throwable.toError()))

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/CleanOperationHandler.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/CleanOperationHandler.kt
@@ -54,7 +54,10 @@ class CleanOperationHandler(
             return
         }
         scope.launch(dispatchers.io) {
-            analyzeFilesUseCase().collectLatest { result: DataState<Pair<List<File>, List<File>>, Errors> ->
+            val scannedFiles = mutableListOf<File>()
+            val emptyFolders = mutableListOf<File>()
+
+            analyzeFilesUseCase().collect { result ->
                 uiState.update { currentState ->
                     val currentData: UiScannerModel = currentState.data ?: UiScannerModel()
                     when (result) {
@@ -67,63 +70,10 @@ class CleanOperationHandler(
                                 )
                             )
                         )
-
                         is DataState.Success -> {
-                            val fileTypesData = currentData.analyzeState.fileTypesData
-                            val preferences = mapOf(
-                                ExtensionsConstants.GENERIC_EXTENSIONS to dataStore.genericFilter.first(),
-                                ExtensionsConstants.IMAGE_EXTENSIONS to dataStore.deleteImageFiles.first(),
-                                ExtensionsConstants.VIDEO_EXTENSIONS to dataStore.deleteVideoFiles.first(),
-                                ExtensionsConstants.AUDIO_EXTENSIONS to dataStore.deleteAudioFiles.first(),
-                                ExtensionsConstants.OFFICE_EXTENSIONS to dataStore.deleteOfficeFiles.first(),
-                                ExtensionsConstants.ARCHIVE_EXTENSIONS to dataStore.deleteArchives.first(),
-                                ExtensionsConstants.APK_EXTENSIONS to dataStore.deleteApkFiles.first(),
-                                ExtensionsConstants.FONT_EXTENSIONS to dataStore.deleteFontFiles.first(),
-                                ExtensionsConstants.WINDOWS_EXTENSIONS to dataStore.deleteWindowsFiles.first(),
-                                ExtensionsConstants.EMPTY_FOLDERS to dataStore.deleteEmptyFolders.first(),
-                                ExtensionsConstants.OTHER_EXTENSIONS to dataStore.deleteOtherFiles.first()
-                            )
-
-                            val includeDuplicates = dataStore.deleteDuplicateFiles.first() &&
-                                    dataStore.duplicateScanEnabled.first()
-                            val (groupedFiles, duplicateOriginals, duplicateGroups) =
-                                withContext(dispatchers.io) {
-                                    fileAnalyzer.computeGroupedFiles(
-                                        scannedFiles = result.data.first,
-                                        emptyFolders = result.data.second,
-                                        fileTypesData = fileTypesData,
-                                        preferences = preferences,
-                                        includeDuplicates = includeDuplicates
-                                    )
-                                }
-                            currentState.copy(
-                                screenState = ScreenState.Success(),
-                                data = currentData.copy(
-                                    analyzeState = currentData.analyzeState.copy(
-                                        scannedFileList = result.data.first.map {
-                                            FileEntry(
-                                                it.absolutePath,
-                                                it.length(),
-                                                it.lastModified()
-                                            )
-                                        },
-                                        emptyFolderList = result.data.second.map {
-                                            FileEntry(
-                                                it.absolutePath,
-                                                0,
-                                                it.lastModified()
-                                            )
-                                        },
-                                        groupedFiles = groupedFiles,
-                                        duplicateOriginals = duplicateOriginals,
-                                        duplicateGroups = duplicateGroups,
-                                        state = CleaningState.ReadyToClean,
-                                        cleaningType = CleaningType.NONE
-                                    )
-                                )
-                            )
+                            scannedFiles.add(result.data)
+                            currentState
                         }
-
                         is DataState.Error -> currentState.copy(
                             screenState = ScreenState.Error(),
                             data = currentData.copy(
@@ -139,6 +89,63 @@ class CleanOperationHandler(
                         )
                     }
                 }
+            }
+
+            getEmptyFoldersUseCase().collect { result ->
+                if (result is DataState.Success) {
+                    emptyFolders.add(result.data)
+                }
+            }
+
+            val currentData = uiState.value.data ?: UiScannerModel()
+            val fileTypesData = currentData.analyzeState.fileTypesData
+            val preferences = mapOf(
+                ExtensionsConstants.GENERIC_EXTENSIONS to dataStore.genericFilter.first(),
+                ExtensionsConstants.IMAGE_EXTENSIONS to dataStore.deleteImageFiles.first(),
+                ExtensionsConstants.VIDEO_EXTENSIONS to dataStore.deleteVideoFiles.first(),
+                ExtensionsConstants.AUDIO_EXTENSIONS to dataStore.deleteAudioFiles.first(),
+                ExtensionsConstants.OFFICE_EXTENSIONS to dataStore.deleteOfficeFiles.first(),
+                ExtensionsConstants.ARCHIVE_EXTENSIONS to dataStore.deleteArchives.first(),
+                ExtensionsConstants.APK_EXTENSIONS to dataStore.deleteApkFiles.first(),
+                ExtensionsConstants.FONT_EXTENSIONS to dataStore.deleteFontFiles.first(),
+                ExtensionsConstants.WINDOWS_EXTENSIONS to dataStore.deleteWindowsFiles.first(),
+                ExtensionsConstants.EMPTY_FOLDERS to dataStore.deleteEmptyFolders.first(),
+                ExtensionsConstants.OTHER_EXTENSIONS to dataStore.deleteOtherFiles.first()
+            )
+
+            val includeDuplicates = dataStore.deleteDuplicateFiles.first() &&
+                    dataStore.duplicateScanEnabled.first()
+            val (groupedFiles, duplicateOriginals, duplicateGroups) =
+                withContext(dispatchers.io) {
+                    fileAnalyzer.computeGroupedFiles(
+                        scannedFiles = scannedFiles,
+                        emptyFolders = emptyFolders,
+                        fileTypesData = fileTypesData,
+                        preferences = preferences,
+                        includeDuplicates = includeDuplicates
+                    )
+                }
+
+            uiState.update { state ->
+                val data = state.data ?: UiScannerModel()
+                state.copy(
+                    screenState = ScreenState.Success(),
+                    data = data.copy(
+                        analyzeState = data.analyzeState.copy(
+                            scannedFileList = scannedFiles.map {
+                                FileEntry(it.absolutePath, it.length(), it.lastModified())
+                            },
+                            emptyFolderList = emptyFolders.map {
+                                FileEntry(it.absolutePath, 0, it.lastModified())
+                            },
+                            groupedFiles = groupedFiles,
+                            duplicateOriginals = duplicateOriginals,
+                            duplicateGroups = duplicateGroups,
+                            state = CleaningState.ReadyToClean,
+                            cleaningType = CleaningType.NONE
+                        )
+                    )
+                )
             }
         }
     }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
@@ -708,13 +708,19 @@ class ScannerViewModel(
 
     private fun loadEmptyFoldersPreview() {
         launch(dispatchers.io) {
-            getEmptyFoldersUseCase().collectLatest { result ->
-                if (result is DataState.Success) {
-                    if (_emptyFoldersHideUntil.value <= System.currentTimeMillis()) {
-                        _emptyFolders.value = result.data
-                    } else {
-                        _emptyFolders.value = emptyList()
+            val folders = mutableListOf<File>()
+            getEmptyFoldersUseCase().collect { result ->
+                when (result) {
+                    is DataState.Loading -> folders.clear()
+                    is DataState.Success -> {
+                        if (_emptyFoldersHideUntil.value <= System.currentTimeMillis()) {
+                            folders.add(result.data)
+                            _emptyFolders.value = folders.toList()
+                        } else {
+                            _emptyFolders.value = emptyList()
+                        }
                     }
+                    else -> {}
                 }
             }
         }


### PR DESCRIPTION
## Summary
- expose streaming APIs in `ScannerRepositoryInterface`
- use `Flow` in `ScannerRepositoryImpl` for file and folder scanning
- update use cases to emit items incrementally
- adapt `CleanOperationHandler` and `ScannerViewModel` to process new streams

## Testing
- `./gradlew tasks --all`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889efda9d48832da33536bb1a6765b3