### PR TITLE
Fix analyze screen empty state

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/AnalyzeScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/AnalyzeScreen.kt
@@ -70,6 +70,8 @@ fun AnalyzeScreen(
                             coroutineScope = coroutineScope,
                             data = data,
                         )
+                    } else {
+                        NoFilesFoundScreen(viewModel = viewModel)
                     }
                 }
 


### PR DESCRIPTION
## Summary
- show a no-files screen on the analyze screen when there are no files

## Testing
- `./gradlew test --dry-run` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a2f4f12b8832da0a3f7a4ec8d46f2