### PR TITLE
Fix APK cleaner loading state

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
@@ -279,15 +279,16 @@ class ScannerViewModel(
 
 
     private fun deleteFiles(files: Set<FileEntry>, fromApkCleaner: Boolean = false) {
+        if (files.isEmpty()) {
+            postSnackbar(
+                message = UiTextHelper.StringResource(R.string.no_files_selected_to_delete),
+                isError = false
+            )
+            return
+        }
+        if (fromApkCleaner) _cleaningApks.value = true
+
         launch(context = dispatchers.io) {
-            if (files.isEmpty()) {
-                postSnackbar(
-                    message = UiTextHelper.StringResource(R.string.no_files_selected_to_delete),
-                    isError = false
-                )
-                return@launch
-            }
-            if (fromApkCleaner) _cleaningApks.value = true
             _uiState.update { state: UiStateScreen<UiScannerModel> ->
                 val currentData: UiScannerModel = state.data ?: UiScannerModel()
                 state.copy(


### PR DESCRIPTION
## Summary
- improve deleteFiles timing so APK cleaning sets loading state before IO work

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a5908b904832d92b05224a9168abc