### PR TITLE
Refactor ContactsCleaner permissions

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/PermissionsHelper.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/PermissionsHelper.kt
@@ -139,7 +139,17 @@ object PermissionsHelper {
         return readGranted && writeGranted
     }
 
-    fun requestContactsPermissions(activity: Activity) { // FIXME: Function "requestContactsPermissions" is never used
+    fun shouldShowContactsPermissionRationale(activity: Activity): Boolean {
+        return ActivityCompat.shouldShowRequestPermissionRationale(
+            activity,
+            Manifest.permission.READ_CONTACTS
+        ) || ActivityCompat.shouldShowRequestPermissionRationale(
+            activity,
+            Manifest.permission.WRITE_CONTACTS
+        )
+    }
+
+    fun requestContactsPermissions(activity: Activity) {
         ActivityCompat.requestPermissions(
             activity,
             arrayOf(
@@ -148,5 +158,13 @@ object PermissionsHelper {
             ),
             AppPermissionsConstants.REQUEST_CODE_CONTACTS_PERMISSIONS
         )
+    }
+
+    fun openAppSettings(activity: Activity) {
+        val intent = Intent(
+            Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+            Uri.fromParts("package", activity.packageName, null)
+        )
+        activity.startActivity(intent)
     }
 }


### PR DESCRIPTION
## Summary
- move contacts permission request logic to `PermissionsHelper`
- reuse helper in `ContactsCleanerScreen`
- add functions for showing rationale and opening app settings

## Testing
- `./gradlew tasks --all`
- `./gradlew lintDebug testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bbed5643c832da11d22388a614cd6