### PR TITLE
Handle bitmap disposal in FilePreviewHelper

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/utils/helpers/FilePreviewHelper.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/utils/helpers/FilePreviewHelper.kt
@@ -426,6 +426,14 @@ object FilePreviewHelper {
                 }
                 val safe = pdfBitmap?.takeUnless { it.isRecycled }
                 if (safe != null) {
+                    DisposableEffect(safe) {
+                        onDispose {
+                            if (!safe.isRecycled) {
+                                android.util.Log.d(TAG, "Recycle bitmap: ${file.path}")
+                                safe.recycle()
+                            }
+                        }
+                    }
                     android.util.Log.d(TAG, "Draw bitmap: ${file.path}")
                     Image(
                         bitmap = safe.asImageBitmap(),
@@ -457,6 +465,14 @@ object FilePreviewHelper {
                 }
                 val safe = bitmap?.takeUnless { it.isRecycled }
                 if (safe != null) {
+                    DisposableEffect(safe) {
+                        onDispose {
+                            if (!safe.isRecycled) {
+                                android.util.Log.d(TAG, "Recycle bitmap: ${file.path}")
+                                safe.recycle()
+                            }
+                        }
+                    }
                     android.util.Log.d(TAG, "Draw bitmap: ${file.path}")
                     Image(
                         bitmap = safe.asImageBitmap(),


### PR DESCRIPTION
## Summary
- dispose of bitmap previews using `DisposableEffect`
- recycle preview bitmaps to avoid leaks

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d06c05fe4832d8a058adecf896abb