### PR TITLE
Cap ByteBuffer allocation for waveforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - **New**: Introduced a link cleaner to remove tracking parameters from URLs before sharing.
 - **Minor**: Improved the UI of the Contacts Cleaner screen.
 - **Minor**: File previews are now faster and more reliable across all lists.
+- **Patch**: Waveform generation caps allocated buffer at 1 MB to avoid
+  crashes on malformed audio files.
 
 # Version 3.5.0:
 


### PR DESCRIPTION
## Summary
- cap ByteBuffer size for waveform generation to 1 MB
- warn when reported size exceeds the cap
- mention the cap in the changelog

## Testing
- `./gradlew test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d0abe7300832db0523fa2af824389