### PR TITLE
Centralize APK preview rendering

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/apps/manager/ui/components/ApkItem.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/apps/manager/ui/components/ApkItem.kt
@@ -24,10 +24,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import coil3.compose.AsyncImage
 import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.IconButton
 import com.d4rk.android.libs.apptoolkit.core.ui.components.dropdown.CommonDropdownMenuItem
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
@@ -35,6 +33,7 @@ import com.d4rk.cleaner.R
 import com.d4rk.cleaner.app.apps.manager.domain.actions.AppManagerEvent
 import com.d4rk.cleaner.app.apps.manager.domain.data.model.AppManagerItem
 import com.d4rk.cleaner.app.apps.manager.ui.AppManagerViewModel
+import com.d4rk.cleaner.app.clean.scanner.utils.helpers.FilePreviewHelper
 import com.d4rk.cleaner.core.utils.helpers.FileSizeFormatter
 import java.io.File
 
@@ -43,13 +42,6 @@ fun ApkItem(apkPath: String, viewModel: AppManagerViewModel, modifier: Modifier)
     val context: Context = LocalContext.current
     val apkFile = File(apkPath)
     var showMenu: Boolean by remember { mutableStateOf(value = false) }
-
-    val model = remember(apkPath) {
-        context.packageManager.getPackageArchiveInfo(
-            apkPath,
-            0
-        )?.applicationInfo?.loadIcon(context.packageManager)
-    }
 
     OutlinedCard(modifier = modifier) {
 
@@ -60,11 +52,9 @@ fun ApkItem(apkPath: String, viewModel: AppManagerViewModel, modifier: Modifier)
                 .clip(RoundedCornerShape(SizeConstants.LargeSize)),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            AsyncImage(
-                model = model,
-                contentDescription = null,
-                modifier = Modifier.size(48.dp),
-                contentScale = ContentScale.Fit
+            FilePreviewHelper.Preview(
+                file = apkFile,
+                modifier = Modifier.size(48.dp)
             )
             Column(
                 modifier = Modifier

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/ApkCleanerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/ApkCleanerCard.kt
@@ -31,12 +31,12 @@ import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import coil3.compose.AsyncImage
 import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.TonalIconButtonWithText
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.SmallVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.cleaner.R
 import com.d4rk.cleaner.app.apps.manager.domain.data.model.ApkInfo
+import com.d4rk.cleaner.app.clean.scanner.utils.helpers.FilePreviewHelper
 import com.d4rk.cleaner.core.utils.helpers.FileSizeFormatter
 import java.io.File
 
@@ -90,23 +90,11 @@ fun ApkCleanerCard(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     preview.forEach { apk ->
-                        val appInfo = remember(apk.path) {
-                            context.packageManager.getPackageArchiveInfo(
-                                apk.path,
-                                0
-                            )?.applicationInfo?.apply {
-                                sourceDir = apk.path
-                                publicSourceDir = apk.path
-                            }
-                        }
-                        val appName = appInfo?.loadLabel(context.packageManager)?.toString()
-                            ?: File(apk.path).name
-                        val icon = appInfo?.loadIcon(context.packageManager)
-
+                        val apkFile = File(apk.path)
                         ApkPreviewItem(
-                            name = appName,
-                            size = FileSizeFormatter.format(apk.size),
-                            icon = icon
+                            file = apkFile,
+                            name = apkFile.name,
+                            size = FileSizeFormatter.format(apk.size)
                         )
                     }
                     if (apkFiles.size > preview.size) {
@@ -146,14 +134,13 @@ fun ApkCleanerCard(
 }
 
 @Composable
-private fun ApkPreviewItem(name: String, size: String, icon: Any?) {
+private fun ApkPreviewItem(file: File, name: String, size: String) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier.width(64.dp)
     ) {
-        AsyncImage(
-            model = icon,
-            contentDescription = null,
+        FilePreviewHelper.Preview(
+            file = file,
             modifier = Modifier.size(48.dp)
         )
         Text(


### PR DESCRIPTION
## Summary
- delegate APK icon rendering to `FilePreviewHelper` for app manager items
- reuse `FilePreviewHelper` in APK cleaner previews

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d18441cbc832d8c313c1d9c2ee353