### PR TITLE
Add resolveActivity checks for implicit intents

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/apps/manager/data/AppPackageManagerImpl.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/apps/manager/data/AppPackageManagerImpl.kt
@@ -2,6 +2,7 @@ package com.d4rk.cleaner.app.apps.manager.data
 
 import android.app.Application
 import android.content.Intent
+import android.content.ActivityNotFoundException
 import android.net.Uri
 import android.provider.Settings
 import androidx.core.content.FileProvider
@@ -32,7 +33,12 @@ class AppPackageManagerImpl(private val application: Application) : ApkInstaller
             )
             installIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
             installIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-            application.startActivity(installIntent)
+            val pm = application.packageManager
+            if (installIntent.resolveActivity(pm) != null) {
+                application.startActivity(installIntent)
+            } else {
+                throw ActivityNotFoundException()
+            }
         }.onSuccess {
             emit(value = DataState.Success(data = Unit))
         }.onFailure { throwable: Throwable ->
@@ -88,7 +94,12 @@ class AppPackageManagerImpl(private val application: Application) : ApkInstaller
             val packageUri: Uri = Uri.fromParts("package", packageName, null)
             appInfoIntent.data = packageUri
             appInfoIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            application.startActivity(appInfoIntent)
+            val pm = application.packageManager
+            if (appInfoIntent.resolveActivity(pm) != null) {
+                application.startActivity(appInfoIntent)
+            } else {
+                throw ActivityNotFoundException()
+            }
         }.onSuccess {
             emit(value = DataState.Success(data = Unit))
         }.onFailure { throwable: Throwable ->
@@ -101,7 +112,12 @@ class AppPackageManagerImpl(private val application: Application) : ApkInstaller
             val uri: Uri = Uri.fromParts("package", packageName, null)
             val intent = Intent(Intent.ACTION_DELETE, uri)
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            application.startActivity(intent)
+            val pm = application.packageManager
+            if (intent.resolveActivity(pm) != null) {
+                application.startActivity(intent)
+            } else {
+                throw ActivityNotFoundException()
+            }
         }.onSuccess {
             emit(value = DataState.Success(Unit))
         }.onFailure { throwable: Throwable ->

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/dashboard/ui/ScannerDashboardScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/dashboard/ui/ScannerDashboardScreen.kt
@@ -2,6 +2,7 @@ package com.d4rk.cleaner.app.clean.dashboard.ui
 
 import android.content.Context
 import android.content.Intent
+import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.Arrangement
@@ -528,7 +529,13 @@ fun ScannerDashboardScreen(
                             index = storageManagerIndex
                         )
                         .animateContentSize(),
-                    onOpen = { context.startActivity(storageManagerIntent) }
+                    onOpen = {
+                        if (storageManagerIntent.resolveActivity(context.packageManager) != null) {
+                            context.startActivity(storageManagerIntent)
+                        } else {
+                            Toast.makeText(context, R.string.no_application_found, Toast.LENGTH_SHORT).show()
+                        }
+                    }
                 )
             }
         }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/link/ui/LinkCleanerActivity.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/link/ui/LinkCleanerActivity.kt
@@ -19,7 +19,12 @@ class LinkCleanerActivity : AppCompatActivity() {
                 type = "text/plain"
                 putExtra(Intent.EXTRA_TEXT, cleaned)
             }
-            startActivity(Intent.createChooser(share, getString(R.string.share_via)))
+            val chooser = Intent.createChooser(share, getString(R.string.share_via))
+            if (share.resolveActivity(packageManager) != null) {
+                startActivity(chooser)
+            } else {
+                Toast.makeText(this, R.string.no_application_found, Toast.LENGTH_SHORT).show()
+            }
         } ?: run {
             Toast.makeText(this, R.string.something_went_wrong, Toast.LENGTH_SHORT).show()
         }

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/FileManagerHelper.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/FileManagerHelper.kt
@@ -1,6 +1,5 @@
 package com.d4rk.cleaner.core.utils.helpers
 
-import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -36,15 +35,17 @@ object FileManagerHelper {
             val mime = context.contentResolver.getType(uri) ?: "*/*"
             val intent = Intent(Intent.ACTION_VIEW).setDataAndType(uri, mime)
             intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-            context.startActivity(intent)
-        }.onFailure { exception ->
-            when (exception) {
-                is ActivityNotFoundException -> Toast.makeText(
+            if (intent.resolveActivity(context.packageManager) != null) {
+                context.startActivity(intent)
+            } else {
+                Toast.makeText(
                     context,
                     context.getString(R.string.no_application_found),
                     Toast.LENGTH_SHORT
                 ).show()
-
+            }
+        }.onFailure { exception ->
+            when (exception) {
                 is IllegalArgumentException -> Toast.makeText(
                     context,
                     context.getString(R.string.something_went_wrong),

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/PermissionsHelper.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/PermissionsHelper.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
+import android.widget.Toast
 import android.net.Uri
 import android.os.Build
 import android.os.Environment
@@ -104,7 +105,11 @@ object PermissionsHelper {
             if (!isAccessGranted(activity)) {
                 val intent = Intent(Settings.ACTION_USAGE_ACCESS_SETTINGS)
                 intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY)
-                activity.startActivity(intent)
+                if (intent.resolveActivity(activity.packageManager) != null) {
+                    activity.startActivity(intent)
+                } else {
+                    Toast.makeText(activity, R.string.no_application_found, Toast.LENGTH_SHORT).show()
+                }
             }
         }
     }
@@ -165,6 +170,10 @@ object PermissionsHelper {
             Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
             Uri.fromParts("package", activity.packageName, null)
         )
-        activity.startActivity(intent)
+        if (intent.resolveActivity(activity.packageManager) != null) {
+            activity.startActivity(intent)
+        } else {
+            Toast.makeText(activity, R.string.no_application_found, Toast.LENGTH_SHORT).show()
+        }
     }
 }


### PR DESCRIPTION
## Summary
- avoid ActivityNotFoundException when sharing cleaned links
- validate installer and app info intents
- guard uninstall intent
- check storage manager launch
- verify file viewer in FileManagerHelper
- add checks for usage access and app settings intents

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d1a832b70832d97cca0561f667249