### PR TITLE
Add icon loading placeholder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing to Smart Cleaner
+
+We welcome pull requests!
+
+* Follow the coding style of existing files.
+* Run `./gradlew ktlintCheck` and `./gradlew test` before submitting.
+* When adding file previews or icons, ensure a placeholder is visible while the actual image loads. Icons loaded via `FilePreviewHelper` must show a visually appropriate placeholder until ready.
+
+

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/apps/manager/ui/components/IconLoadingPlaceholder.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/apps/manager/ui/components/IconLoadingPlaceholder.kt
@@ -1,0 +1,29 @@
+package com.d4rk.cleaner.app.apps.manager.ui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.shimmerEffect
+
+/**
+ * Simple circular shimmer used while an icon loads.
+ */
+@Composable
+fun IconLoadingPlaceholder(iconRes: Int, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .size(48.dp)
+            .clip(CircleShape)
+            .shimmerEffect(),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(painter = painterResource(id = iconRes), contentDescription = null)
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/utils/helpers/FilePreviewHelper.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/utils/helpers/FilePreviewHelper.kt
@@ -34,7 +34,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.layout.matchParentSize
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -417,12 +416,12 @@ object FilePreviewHelper {
                     }
                 }
                 Box(modifier = modifier.size(48.dp), contentAlignment = Alignment.Center) {
-                    IconLoadingPlaceholder(iconRes = R.drawable.ic_apk_document, modifier = Modifier.matchParentSize())
+                    IconLoadingPlaceholder(iconRes = R.drawable.ic_apk_document, modifier = Modifier.fillMaxSize())
                     icon?.let { loaded ->
                         AsyncImage(
                             model = ImageRequest.Builder(context).data(loaded).crossfade(true).build(),
                             contentDescription = file.name,
-                            modifier = Modifier.matchParentSize(),
+                            modifier = Modifier.fillMaxSize(),
                             contentScale = ContentScale.Fit
                         )
                     }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/utils/helpers/FilePreviewHelper.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/utils/helpers/FilePreviewHelper.kt
@@ -13,6 +13,7 @@ import android.media.MediaMetadataRetriever
 import android.util.LruCache
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -33,6 +34,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.matchParentSize
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -45,6 +47,7 @@ import coil3.request.crossfade
 import coil3.video.VideoFrameDecoder
 import coil3.video.videoFramePercent
 import com.d4rk.cleaner.R
+import com.d4rk.cleaner.app.apps.manager.ui.components.IconLoadingPlaceholder
 import com.google.common.io.Files.getFileExtension
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -413,18 +416,16 @@ object FilePreviewHelper {
                         }?.loadIcon(context.packageManager)
                     }
                 }
-                if (icon != null) {
-                    AsyncImage(
-                        model = icon,
-                        contentDescription = file.name,
-                        modifier = modifier.size(48.dp)
-                    )
-                } else {
-                    Icon(
-                        painter = painterResource(id = R.drawable.ic_apk_document),
-                        contentDescription = null,
-                        modifier = modifier.size(48.dp)
-                    )
+                Box(modifier = modifier.size(48.dp), contentAlignment = Alignment.Center) {
+                    IconLoadingPlaceholder(iconRes = R.drawable.ic_apk_document, modifier = Modifier.matchParentSize())
+                    icon?.let { loaded ->
+                        AsyncImage(
+                            model = ImageRequest.Builder(context).data(loaded).crossfade(true).build(),
+                            contentDescription = file.name,
+                            modifier = Modifier.matchParentSize(),
+                            contentScale = ContentScale.Fit
+                        )
+                    }
                 }
             }
 

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/PermissionsHelper.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/PermissionsHelper.kt
@@ -14,6 +14,7 @@ import android.os.Environment
 import android.provider.Settings
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import com.d4rk.cleaner.R
 import com.d4rk.cleaner.core.utils.constants.permissions.AppPermissionsConstants
 
 /**

--- a/docs/file_preview_helper.md
+++ b/docs/file_preview_helper.md
@@ -15,7 +15,8 @@ thumbnail when possible (images, videos, PDFs, APKs) or falls back to an icon. E
 Preview generation happens off the UI thread using Kotlin coroutines. Heavy work
 like parsing archives or decoding album art runs on a background dispatcher and
 updates Compose state once finished. While a preview is loading, a fallback icon
-is shown.
+is shown. Icons loaded through `FilePreviewHelper` must never appear blank – a
+loading placeholder is always displayed until the real icon is ready.
 
 Plain text files (`.txt`, `.log`, `.csv`, etc.) display the first three lines of
 content when readable. Large or binary files automatically fall back to the


### PR DESCRIPTION
## Summary
- add a generic `IconLoadingPlaceholder` composable
- show placeholder while APK icons load in FilePreviewHelper
- document icon placeholder requirement in contributor guide and helper docs

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d1d161f78832d8a0f5a2871dd8c73