### PR TITLE
feat: show determinate progress for cleanup jobs

### DIFF
--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -431,4 +431,9 @@
     <string name="failed_to_update_trash_size">فشل في تحديث حجم القمامة: %1$s</string>
     <string name="no_cleaning_options_selected">يرجى اختيار تفضيلات التنظيف الخاصة بك في الإعدادات للمتابعة.</string>
     <string name="cleaning_in_progress">جاري التنظيف</string>
+    <string name="cleanup_progress">تم تنظيف %1$d/%2$d ملف</string>
+    <string name="cleanup_finished">اكتمل التنظيف</string>
+    <string name="cleanup_failed">فشل التنظيف</string>
+    <string name="cleanup_failed_details">تعذر حذف بعض الملفات</string>
+    <string name="cleanup_cancelled">تم إلغاء التنظيف</string>
 </resources>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -398,4 +398,9 @@
     <string name="failed_to_update_trash_size">Неуспешно актуализиране на размера на боклука: %1$s</string>
     <string name="no_cleaning_options_selected">Моля, изберете вашите предпочитания за почистване в настройките, за да продължите.</string>
     <string name="cleaning_in_progress">Почистването е в ход</string>
+    <string name="cleanup_progress">%1$d/%2$d файла почистени</string>
+    <string name="cleanup_finished">Почистването приключи</string>
+    <string name="cleanup_failed">Почистването се провали</string>
+    <string name="cleanup_failed_details">Някои файлове не можаха да бъдат изтрити</string>
+    <string name="cleanup_cancelled">Почистването е отменено</string>
 </resources>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -398,4 +398,9 @@
     <string name="failed_to_update_trash_size">আবর্জনার আকার আপডেট করতে ব্যর্থ: %1$s</string>
     <string name="no_cleaning_options_selected">এগিয়ে যেতে সেটিংসে আপনার পরিষ্কারের পছন্দগুলি চয়ন করুন।</string>
     <string name="cleaning_in_progress">পরিষ্কার চলছে</string>
+    <string name="cleanup_progress">%1$d/%2$d টি ফাইল পরিষ্কার করা হয়েছে</string>
+    <string name="cleanup_finished">পরিষ্কার সম্পন্ন</string>
+    <string name="cleanup_failed">পরিষ্কার ব্যর্থ হয়েছে</string>
+    <string name="cleanup_failed_details">কিছু ফাইল মুছে ফেলা যায়নি</string>
+    <string name="cleanup_cancelled">পরিষ্কার বাতিল করা হয়েছে</string>
 </resources>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -398,4 +398,10 @@
     <string name="no_files_selected_to_clean">Keine zum Reinigen ausgewählten Dateien.</string>
     <string name="failed_to_update_trash_size">Die Müllgröße nicht aktualisieren: %1$s</string>
     <string name="no_cleaning_options_selected">Bitte wählen Sie Ihre Reinigungseinstellungen in Einstellungen, um fortzufahren.</string>
-    <string name="cleaning_in_progress">Reinigung läuft</string></resources>
+    <string name="cleaning_in_progress">Reinigung läuft</string>
+    <string name="cleanup_progress">%1$d/%2$d Dateien bereinigt</string>
+    <string name="cleanup_finished">Bereinigung abgeschlossen</string>
+    <string name="cleanup_failed">Bereinigung fehlgeschlagen</string>
+    <string name="cleanup_failed_details">Einige Dateien konnten nicht gelöscht werden</string>
+    <string name="cleanup_cancelled">Bereinigung abgebrochen</string>
+</resources>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -407,4 +407,9 @@
     <string name="failed_to_update_trash_size">No se pudo actualizar el tamaño de la basura: %1$s</string>
     <string name="no_cleaning_options_selected">Elija sus preferencias de limpieza en Configuración para continuar.</string>
     <string name="cleaning_in_progress">Limpieza en curso</string>
+    <string name="cleanup_progress">%1$d/%2$d archivos limpiados</string>
+    <string name="cleanup_finished">Limpieza finalizada</string>
+    <string name="cleanup_failed">Limpieza fallida</string>
+    <string name="cleanup_failed_details">No se pudieron eliminar algunos archivos</string>
+    <string name="cleanup_cancelled">Limpieza cancelada</string>
 </resources>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -406,4 +406,10 @@
     <string name="no_files_selected_to_clean">No hay archivos seleccionados para limpiar.</string>
     <string name="failed_to_update_trash_size">No se pudo actualizar el tamaño de la basura: %1$s</string>
     <string name="no_cleaning_options_selected">Elija sus preferencias de limpieza en Configuración para continuar.</string>
-    <string name="cleaning_in_progress">Limpieza en curso</string></resources>
+    <string name="cleaning_in_progress">Limpieza en curso</string>
+    <string name="cleanup_progress">%1$d/%2$d archivos limpiados</string>
+    <string name="cleanup_finished">Limpieza finalizada</string>
+    <string name="cleanup_failed">Limpieza fallida</string>
+    <string name="cleanup_failed_details">No se pudieron eliminar algunos archivos</string>
+    <string name="cleanup_cancelled">Limpieza cancelada</string>
+</resources>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -399,4 +399,9 @@
     <string name="failed_to_update_trash_size">Nabigong i -update ang laki ng basurahan: %1$s</string>
     <string name="no_cleaning_options_selected">Mangyaring piliin ang iyong mga kagustuhan sa paglilinis sa mga setting upang magpatuloy.</string>
     <string name="cleaning_in_progress">Isinasagawa ang paglilinis</string>
+    <string name="cleanup_progress">%1$d/%2$d file nalinis</string>
+    <string name="cleanup_finished">Tapos na ang paglilinis</string>
+    <string name="cleanup_failed">Nabigo ang paglilinis</string>
+    <string name="cleanup_failed_details">May ilang file na hindi matanggal</string>
+    <string name="cleanup_cancelled">Kinansela ang paglilinis</string>
 </resources>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -408,4 +408,9 @@
     <string name="failed_to_update_trash_size">Échec de la mise à jour de la taille des poubelles: %1$s</string>
     <string name="no_cleaning_options_selected">Veuillez choisir vos préférences de nettoyage dans les paramètres pour continuer.</string>
     <string name="cleaning_in_progress">Nettoyage en cours</string>
+    <string name="cleanup_progress">%1$d/%2$d fichiers nettoyés</string>
+    <string name="cleanup_finished">Nettoyage terminé</string>
+    <string name="cleanup_failed">Échec du nettoyage</string>
+    <string name="cleanup_failed_details">Certains fichiers n\'ont pas pu être supprimés</string>
+    <string name="cleanup_cancelled">Nettoyage annulé</string>
 </resources>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -399,4 +399,9 @@
     <string name="failed_to_update_trash_size">कचरा आकार अपडेट करने में विफल: %1$s</string>
     <string name="no_cleaning_options_selected">कृपया आगे बढ़ने के लिए सेटिंग्स में अपनी सफाई वरीयताएँ चुनें।</string>
     <string name="cleaning_in_progress">सफाई जारी है</string>
+    <string name="cleanup_progress">%1$d/%2$d फ़ाइलें साफ़ की गईं</string>
+    <string name="cleanup_finished">सफाई पूरी हुई</string>
+    <string name="cleanup_failed">सफाई असफल रही</string>
+    <string name="cleanup_failed_details">कुछ फ़ाइलें हटाई नहीं जा सकीं</string>
+    <string name="cleanup_cancelled">सफाई रद्द की गई</string>
 </resources>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -399,4 +399,9 @@
     <string name="failed_to_update_trash_size">Nem sikerült frissíteni a szemét méretét: %1$s</string>
     <string name="no_cleaning_options_selected">Kérjük, válassza ki a tisztítási beállításokat a beállításokban.</string>
     <string name="cleaning_in_progress">Tisztítás folyamatban</string>
+    <string name="cleanup_progress">%1$d/%2$d fájl törölve</string>
+    <string name="cleanup_finished">Tisztítás befejezve</string>
+    <string name="cleanup_failed">Tisztítás sikertelen</string>
+    <string name="cleanup_failed_details">Néhány fájlt nem sikerült törölni</string>
+    <string name="cleanup_cancelled">Tisztítás megszakítva</string>
 </resources>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -390,4 +390,10 @@
     <string name="no_files_selected_to_clean">Tidak ada file yang dipilih untuk dibersihkan.</string>
     <string name="failed_to_update_trash_size">Gagal memperbarui ukuran sampah: %1$s</string>
     <string name="no_cleaning_options_selected">Pilih preferensi pembersihan Anda dalam pengaturan untuk melanjutkan.</string>
-    <string name="cleaning_in_progress">Pembersihan sedang berlangsung</string></resources>
+    <string name="cleaning_in_progress">Pembersihan sedang berlangsung</string>
+    <string name="cleanup_progress">%1$d/%2$d file dibersihkan</string>
+    <string name="cleanup_finished">Pembersihan selesai</string>
+    <string name="cleanup_failed">Pembersihan gagal</string>
+    <string name="cleanup_failed_details">Beberapa file tidak dapat dihapus</string>
+    <string name="cleanup_cancelled">Pembersihan dibatalkan</string>
+</resources>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -406,4 +406,10 @@
     <string name="no_files_selected_to_clean">Nessun file selezionato per pulire.</string>
     <string name="failed_to_update_trash_size">Impossibile aggiornare la dimensione della spazzatura: %1$s</string>
     <string name="no_cleaning_options_selected">Scegli le tue preferenze di pulizia nelle impostazioni per procedere.</string>
-    <string name="cleaning_in_progress">Pulizia in corso</string></resources>
+    <string name="cleaning_in_progress">Pulizia in corso</string>
+    <string name="cleanup_progress">%1$d/%2$d file puliti</string>
+    <string name="cleanup_finished">Pulizia completata</string>
+    <string name="cleanup_failed">Pulizia non riuscita</string>
+    <string name="cleanup_failed_details">Impossibile eliminare alcuni file</string>
+    <string name="cleanup_cancelled">Pulizia annullata</string>
+</resources>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -390,4 +390,10 @@
     <string name="no_files_selected_to_clean">クリーニングするために選択されたファイルはありません。</string>
     <string name="failed_to_update_trash_size">ゴミのサイズの更新に失敗しました：%1$s</string>
     <string name="no_cleaning_options_selected">続行するには、設定のクリーニング設定を選択してください。</string>
-    <string name="cleaning_in_progress">クリーンアップを実行中</string></resources>
+    <string name="cleaning_in_progress">クリーンアップを実行中</string>
+    <string name="cleanup_progress">%1$d/%2$d 件のファイルをクリーンアップ済み</string>
+    <string name="cleanup_finished">クリーンアップ完了</string>
+    <string name="cleanup_failed">クリーンアップに失敗しました</string>
+    <string name="cleanup_failed_details">一部のファイルを削除できませんでした</string>
+    <string name="cleanup_cancelled">クリーンアップをキャンセルしました</string>
+</resources>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -390,4 +390,10 @@
     <string name="no_files_selected_to_clean">청소할 파일이 없습니다.</string>
     <string name="failed_to_update_trash_size">쓰레기 크기를 업데이트하지 못했습니다 : %1$s</string>
     <string name="no_cleaning_options_selected">진행할 설정에서 청소 환경 설정을 선택하십시오.</string>
-    <string name="cleaning_in_progress">정리 진행 중</string></resources>
+    <string name="cleaning_in_progress">정리 진행 중</string>
+    <string name="cleanup_progress">%1$d/%2$d개의 파일 정리됨</string>
+    <string name="cleanup_finished">정리 완료</string>
+    <string name="cleanup_failed">정리에 실패했습니다</string>
+    <string name="cleanup_failed_details">일부 파일을 삭제할 수 없습니다</string>
+    <string name="cleanup_cancelled">정리가 취소되었습니다</string>
+</resources>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -414,4 +414,10 @@
     <string name="no_files_selected_to_clean">Brak plików do czyszczenia.</string>
     <string name="failed_to_update_trash_size">Nie udało się zaktualizować rozmiaru śmieci: %1$s</string>
     <string name="no_cleaning_options_selected">Wybierz swoje preferencje czyszczące w ustawieniach, aby kontynuować.</string>
-    <string name="cleaning_in_progress">Trwa czyszczenie</string></resources>
+    <string name="cleaning_in_progress">Trwa czyszczenie</string>
+    <string name="cleanup_progress">%1$d/%2$d plików wyczyszczono</string>
+    <string name="cleanup_finished">Czyszczenie zakończone</string>
+    <string name="cleanup_failed">Czyszczenie nie powiodło się</string>
+    <string name="cleanup_failed_details">Niektórych plików nie można było usunąć</string>
+    <string name="cleanup_cancelled">Czyszczenie anulowane</string>
+</resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -406,4 +406,10 @@
     <string name="no_files_selected_to_clean">Nenhum arquivo selecionado para limpar.</string>
     <string name="failed_to_update_trash_size">Falha ao atualizar o tamanho do lixo: %1$s</string>
     <string name="no_cleaning_options_selected">Escolha suas preferências de limpeza nas configurações para prosseguir.</string>
-    <string name="cleaning_in_progress">Limpeza em andamento</string></resources>
+    <string name="cleaning_in_progress">Limpeza em andamento</string>
+    <string name="cleanup_progress">%1$d/%2$d arquivos limpos</string>
+    <string name="cleanup_finished">Limpeza concluída</string>
+    <string name="cleanup_failed">Falha na limpeza</string>
+    <string name="cleanup_failed_details">Alguns arquivos não puderam ser excluídos</string>
+    <string name="cleanup_cancelled">Limpeza cancelada</string>
+</resources>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -406,4 +406,10 @@
     <string name="no_files_selected_to_clean">Nu există fișiere selectate pentru a curăța.</string>
     <string name="failed_to_update_trash_size">Nu a reușit să actualizeze dimensiunea gunoiului: %1$s</string>
     <string name="no_cleaning_options_selected">Vă rugăm să alegeți preferințele dvs. de curățare în setări pentru a continua.</string>
-    <string name="cleaning_in_progress">Curățare în curs</string></resources>
+    <string name="cleaning_in_progress">Curățare în curs</string>
+    <string name="cleanup_progress">%1$d/%2$d fișiere curățate</string>
+    <string name="cleanup_finished">Curățare finalizată</string>
+    <string name="cleanup_failed">Curățare eșuată</string>
+    <string name="cleanup_failed_details">Unele fișiere nu au putut fi șterse</string>
+    <string name="cleanup_cancelled">Curățare anulată</string>
+</resources>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -414,4 +414,10 @@
     <string name="no_files_selected_to_clean">Нет файлов, выбранных для очистки.</string>
     <string name="failed_to_update_trash_size">Не удалось обновить размер мусора: %1$s</string>
     <string name="no_cleaning_options_selected">Пожалуйста, выберите свои предпочтения в уборке в настройках, чтобы продолжить.</string>
-    <string name="cleaning_in_progress">Идет очистка</string></resources>
+    <string name="cleaning_in_progress">Идет очистка</string>
+    <string name="cleanup_progress">Очищено %1$d/%2$d файлов</string>
+    <string name="cleanup_finished">Очистка завершена</string>
+    <string name="cleanup_failed">Очистка не удалась</string>
+    <string name="cleanup_failed_details">Некоторые файлы не удалось удалить</string>
+    <string name="cleanup_cancelled">Очистка отменена</string>
+</resources>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -398,4 +398,10 @@
     <string name="no_files_selected_to_clean">Inga filer valda för att rengöra.</string>
     <string name="failed_to_update_trash_size">Det gick inte att uppdatera skräpstorlek: %1$s</string>
     <string name="no_cleaning_options_selected">Välj dina rengöringspreferenser i inställningar för att fortsätta.</string>
-    <string name="cleaning_in_progress">Rensning pågår</string></resources>
+    <string name="cleaning_in_progress">Rensning pågår</string>
+    <string name="cleanup_progress">%1$d/%2$d filer rensade</string>
+    <string name="cleanup_finished">Rensning klar</string>
+    <string name="cleanup_failed">Rensning misslyckades</string>
+    <string name="cleanup_failed_details">Vissa filer kunde inte tas bort</string>
+    <string name="cleanup_cancelled">Rensning avbruten</string>
+</resources>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -391,4 +391,9 @@
     <string name="failed_to_update_trash_size">ไม่สามารถอัปเดตขนาดถังขยะ: %1$s</string>
     <string name="no_cleaning_options_selected">โปรดเลือกการตั้งค่าการทำความสะอาดของคุณในการตั้งค่าเพื่อดำเนินการต่อ</string>
     <string name="cleaning_in_progress">กำลังทำความสะอาด</string>
+    <string name="cleanup_progress">ล้างแล้ว %1$d/%2$d ไฟล์</string>
+    <string name="cleanup_finished">ล้างเสร็จแล้ว</string>
+    <string name="cleanup_failed">การล้างล้มเหลว</string>
+    <string name="cleanup_failed_details">ไม่สามารถลบไฟล์บางไฟล์ได้</string>
+    <string name="cleanup_cancelled">ยกเลิกการล้าง</string>
 </resources>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -398,4 +398,10 @@
     <string name="no_files_selected_to_clean">Temizlemek için dosya seçilmedi.</string>
     <string name="failed_to_update_trash_size">Çöp Boyutunu Güncelleme: %1$s</string>
     <string name="no_cleaning_options_selected">Lütfen devam etmek için ayarlarda temizlik tercihlerinizi seçin.</string>
-    <string name="cleaning_in_progress">Temizlik devam ediyor</string></resources>
+    <string name="cleaning_in_progress">Temizlik devam ediyor</string>
+    <string name="cleanup_progress">%1$d/%2$d dosya temizlendi</string>
+    <string name="cleanup_finished">Temizlik tamamlandı</string>
+    <string name="cleanup_failed">Temizlik başarısız</string>
+    <string name="cleanup_failed_details">Bazı dosyalar silinemedi</string>
+    <string name="cleanup_cancelled">Temizlik iptal edildi</string>
+</resources>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -414,4 +414,10 @@
     <string name="no_files_selected_to_clean">Жодних файлів, вибраних для очищення.</string>
     <string name="failed_to_update_trash_size">Не вдалося оновити розмір сміття: %1$s</string>
     <string name="no_cleaning_options_selected">Будь ласка, виберіть свої вподобання прибирання в налаштуваннях для продовження.</string>
-    <string name="cleaning_in_progress">Триває очищення</string></resources>
+    <string name="cleaning_in_progress">Триває очищення</string>
+    <string name="cleanup_progress">Очищено %1$d/%2$d файлів</string>
+    <string name="cleanup_finished">Очищення завершено</string>
+    <string name="cleanup_failed">Очищення не вдалося</string>
+    <string name="cleanup_failed_details">Деякі файли не вдалося видалити</string>
+    <string name="cleanup_cancelled">Очищення скасовано</string>
+</resources>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -399,4 +399,9 @@
     <string name="failed_to_update_trash_size">کوڑے دان کے سائز کو اپ ڈیٹ کرنے میں ناکام: %1$s</string>
     <string name="no_cleaning_options_selected">براہ کرم آگے بڑھنے کے لئے ترتیبات میں اپنی صفائی کی ترجیحات کا انتخاب کریں۔</string>
     <string name="cleaning_in_progress">صفائی جاری ہے</string>
+    <string name="cleanup_progress">%1$d/%2$d فائلیں صاف ہوئیں</string>
+    <string name="cleanup_finished">صفائی مکمل</string>
+    <string name="cleanup_failed">صفائی ناکام</string>
+    <string name="cleanup_failed_details">کچھ فائلیں حذف نہیں ہو سکیں</string>
+    <string name="cleanup_cancelled">صفائی منسوخ کی گئی</string>
 </resources>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -390,4 +390,10 @@
     <string name="no_files_selected_to_clean">Không có tệp được chọn để làm sạch.</string>
     <string name="failed_to_update_trash_size">Không cập nhật kích thước rác: %1$s</string>
     <string name="no_cleaning_options_selected">Vui lòng chọn tùy chọn làm sạch của bạn trong cài đặt để tiếp tục.</string>
-    <string name="cleaning_in_progress">Đang dọn dẹp</string></resources>
+    <string name="cleaning_in_progress">Đang dọn dẹp</string>
+    <string name="cleanup_progress">%1$d/%2$d tệp đã được dọn</string>
+    <string name="cleanup_finished">Dọn dẹp xong</string>
+    <string name="cleanup_failed">Dọn dẹp thất bại</string>
+    <string name="cleanup_failed_details">Không thể xóa một số tệp</string>
+    <string name="cleanup_cancelled">Đã hủy dọn dẹp</string>
+</resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -391,4 +391,9 @@
     <string name="failed_to_update_trash_size">更新垃圾桶大小失敗：%1$s</string>
     <string name="no_cleaning_options_selected">請在設定中選擇您的清理偏好以繼續。</string>
     <string name="cleaning_in_progress">正在清理中</string>
+    <string name="cleanup_progress">已清理 %1$d/%2$d 個檔案</string>
+    <string name="cleanup_finished">清理完成</string>
+    <string name="cleanup_failed">清理失敗</string>
+    <string name="cleanup_failed_details">部分檔案無法刪除</string>
+    <string name="cleanup_cancelled">清理已取消</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -399,4 +399,9 @@
     <string name="failed_to_update_trash_size">Failed to update trash size: %1$s</string>
     <string name="no_cleaning_options_selected">Please choose your cleaning preferences in settings to proceed.</string>
     <string name="cleaning_in_progress">Cleaning in progress</string>
+    <string name="cleanup_progress">%1$d/%2$d files cleaned</string>
+    <string name="cleanup_finished">Cleanup finished</string>
+    <string name="cleanup_failed">Cleanup failed</string>
+    <string name="cleanup_failed_details">Some files could not be deleted</string>
+    <string name="cleanup_cancelled">Cleanup cancelled</string>
 </resources>

--- a/docs/cleanup_jobs.md
+++ b/docs/cleanup_jobs.md
@@ -7,6 +7,14 @@ if the process was killed or the work was deferred. An in-process
 `CleaningEventBus` can dispatch fast updates, but `WorkInfo` remains the source
 of truth and must always be observed when launching cleanup work.
 
+## Notifications
+
+Each cleanup job runs in the foreground and surfaces a determinate notification
+showing exact progress (for example `27/184 files cleaned`). The notification is
+updated as files are processed and, once finished, displays a success, failure or
+cancelled message. The final state remains visible for a few seconds before the
+notification is dismissed.
+
 ## Job Lifecycle and UI Sync
 
 Cleanup work IDs are persisted to `DataStore` immediately after enqueuing to


### PR DESCRIPTION
## Summary
- show exact progress for file cleanup in a foreground notification
- add success, failure, and cancellation messages that linger briefly
- document cleanup notifications

## Testing
- `ANDROID_HOME=/usr/lib/android-sdk ./gradlew test` *(fails: Failed to install the following Android SDK packages as some licences have not been accepted)*

------
https://chatgpt.com/codex/tasks/task_e_688e21fb1218832da5225e04cc5e1e90