### PR TITLE
docs: clarify cleanup job behavior

### DIFF
--- a/docs/cleanup_jobs.md
+++ b/docs/cleanup_jobs.md
@@ -1,5 +1,7 @@
 # Cleanup Job System: Technical and UX Documentation
 
+Smart Cleaner performs cleanup tasks only when the user explicitly initiates them. Each job runs in the foreground with determinate progress notifications, and its state is preserved so progress can resume after crashes or restarts.
+
 ## Overview
 Smart Cleaner runs all file deletion and trash moves through WorkManager jobs. Every job begins with explicit user action and presents real-time progress in the UI and notification bar.
 


### PR DESCRIPTION
## Summary
- note that cleanup jobs are user-triggered and run in the foreground with determinate progress
- highlight that job state is recoverable after crashes or restarts

## Testing
- `./gradlew test` *(fails: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_688e31285b54832d95baeb7072881653