### PR TITLE
docs: note progress notification recovery

### DIFF
--- a/docs/cleanup_jobs.md
+++ b/docs/cleanup_jobs.md
@@ -24,6 +24,7 @@ Smart Cleaner runs all file deletion and trash moves through WorkManager jobs. E
 
 ### Process Death & Recovery
 * On restart, any persisted job IDs are used to reattach observers to the running WorkManager jobs so progress continues seamlessly.
+* If the OS removes the progress notification, the app reattaches to the job on restart and shows the current state.
 * If an ID does not match any existing `WorkInfo`, it is cleared automatically.
 
 ## UX & Notification Policy


### PR DESCRIPTION
## Summary
- document that if Android removes the progress notification, the app reconnects to the job on restart and shows its current state

## Testing
- `./gradlew test --no-daemon` *(fails: process stops after generating debug build config; see logs)*

------
https://chatgpt.com/codex/tasks/task_e_688e3718b604832daab1a1ddad8cdb6c