### PR TITLE
docs: note scan lists are transient

### DIFF
--- a/docs/cleaning_screens.md
+++ b/docs/cleaning_screens.md
@@ -24,6 +24,7 @@
 - Results streamed via `MutableStateFlow` to the UI.
 - File metadata is cached in RAM for the session only.
 - File selections are transient and not persisted.
+- Both scan results and selections live only in memory; if the process dies they are cleared and require a new scan.
 
 ## 3. File Discovery, Storage, and Cleaning Flow
 **File discovery**

--- a/docs/cleanup_jobs.md
+++ b/docs/cleanup_jobs.md
@@ -26,6 +26,7 @@ Smart Cleaner runs all file deletion and trash moves through WorkManager jobs. E
 * On restart, any persisted job IDs are used to reattach observers to the running WorkManager jobs so progress continues seamlessly.
 * If the OS removes the progress notification, the app reattaches to the job on restart and shows the current state.
 * If an ID does not match any existing `WorkInfo`, it is cleared automatically.
+* Scan results and file selections exist only in RAM. If the process dies before a job starts, these lists reset and require a fresh scan and selection.
 
 ## UX & Notification Policy
 * **Single job per feature:** The app never allows overlapping cleanup jobs for the same feature.


### PR DESCRIPTION
## Summary
- Clarify that scan results and file selections are held only in memory
- Document that these lists reset if the app process dies, requiring a rescan

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e3b7022ec832dbd30741ad0df849e