### PR TITLE
Improve duplicate detection with cached parallel hashing

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/domain/usecases/GetDuplicatesUseCase.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/domain/usecases/GetDuplicatesUseCase.kt
@@ -1,0 +1,51 @@
+package com.d4rk.cleaner.app.clean.scanner.domain.usecases
+
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
+import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.FileEntry
+import com.d4rk.cleaner.core.utils.extensions.partialMd5
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+
+class GetDuplicatesUseCase(
+    private val dispatchers: DispatcherProvider
+) {
+    private val hashCache = ConcurrentHashMap<String, String>()
+    private val chunkSize = 100
+
+    operator fun invoke(files: List<File>): List<List<FileEntry>> = runBlocking {
+        val candidates = files.filter { it.isFile }
+            .groupBy { it.length() to it.lastModified() }
+            .values
+            .filter { it.size > 1 }
+            .flatten()
+
+        if (candidates.isEmpty()) return@runBlocking emptyList<List<FileEntry>>()
+
+        val hashed = coroutineScope {
+            candidates.chunked(chunkSize).map { chunk ->
+                async {
+                    withContext(dispatchers.io) {
+                        chunk.mapNotNull { file ->
+                            val key = "${file.absolutePath}:${file.lastModified()}"
+                            val hash = hashCache[key] ?: file.partialMd5()?.also { hashCache[key] = it }
+                            hash?.let { it to file }
+                        }
+                    }
+                }
+            }.awaitAll().flatten()
+        }
+
+        hashed.groupBy({ it.first }, { it.second })
+            .values
+            .filter { it.size > 1 }
+            .map { group ->
+                group.map { f -> FileEntry(f.absolutePath, f.length(), f.lastModified()) }
+            }
+    }
+}
+

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/di/modules/AppModule.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/di/modules/AppModule.kt
@@ -113,7 +113,8 @@ val appModule: Module = module {
     single<DeleteFilesUseCase> { DeleteFilesUseCase(homeRepository = get()) }
     single<MoveToTrashUseCase> { MoveToTrashUseCase(homeRepository = get()) }
     single<UpdateTrashSizeUseCase> { UpdateTrashSizeUseCase(homeRepository = get()) }
-    single { com.d4rk.cleaner.app.clean.scanner.domain.operations.FileAnalyzer() }
+    single { com.d4rk.cleaner.app.clean.scanner.domain.usecases.GetDuplicatesUseCase(dispatchers = get()) }
+    single { com.d4rk.cleaner.app.clean.scanner.domain.operations.FileAnalyzer(get()) }
     single {
         com.d4rk.cleaner.app.clean.scanner.domain.operations.CleaningManager(
             deleteFilesUseCase = get(),


### PR DESCRIPTION
## Summary
- add `GetDuplicatesUseCase` to pre-filter by size/modified date, cache hashes and hash in parallel
- wire new use case into `FileAnalyzer` and dependency graph

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68906725bde0832d8303cc6737b94b37