### PR TITLE
Fix build by removing Android 14-only foreground service types

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/work/FileCleanupWorker.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/work/FileCleanupWorker.kt
@@ -4,7 +4,6 @@ import android.Manifest
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
-import android.content.pm.ServiceInfo
 import android.os.Build
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
@@ -59,7 +58,6 @@ class FileCleanupWorker(
             .setOnlyAlertOnce(true)
             .setOngoing(true)
             .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
-            .setForegroundServiceTypes(ServiceInfo.FOREGROUND_SERVICE_TYPE_FILE_MANAGEMENT)
 
         val total = files.size
         var processed = 0
@@ -188,7 +186,7 @@ class FileCleanupWorker(
         return ForegroundInfo(
             NOTIFICATION_ID,
             notification,
-            ServiceInfo.FOREGROUND_SERVICE_TYPE_FILE_MANAGEMENT,
+            FOREGROUND_SERVICE_TYPE_FILE_MANAGEMENT,
         )
     }
 
@@ -203,5 +201,6 @@ class FileCleanupWorker(
         private const val NOTIFICATION_ID = 2001
         private const val NOTIFICATION_CHANNEL = "file_cleanup"
         private const val FINISH_DELAY_MS = 4000L
+        private const val FOREGROUND_SERVICE_TYPE_FILE_MANAGEMENT = 1 shl 12
     }
 }


### PR DESCRIPTION
## Summary
- avoid using setForegroundServiceTypes and the Android 14 constant that caused unresolved references
- define a constant for the file management service type when creating the worker's ForegroundInfo

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689090be2b74832d93b1f522f6ac4bf0