### PR TITLE
Remove expedited flag from large file cleanup

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/largefiles/ui/LargeFilesViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/largefiles/ui/LargeFilesViewModel.kt
@@ -2,7 +2,6 @@ package com.d4rk.cleaner.app.clean.largefiles.ui
 
 import android.app.Application
 import androidx.work.OneTimeWorkRequestBuilder
-import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.workDataOf
@@ -156,7 +155,6 @@ class LargeFilesViewModel(
             var lastRequest: androidx.work.OneTimeWorkRequest? = null
             for (chunk in chunks) {
                 val request = OneTimeWorkRequestBuilder<FileCleanupWorker>()
-                    .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                     .setInputData(
                         workDataOf(
                             FileCleanupWorker.KEY_ACTION to FileCleanupWorker.ACTION_DELETE,


### PR DESCRIPTION
## Summary
- queue large file cleanup work as standard OneTimeWorkRequests

## Testing
- `./gradlew --console=plain :app:compileDebugKotlin`
- `./gradlew --console=plain :app:testDebugUnitTest`


------
https://chatgpt.com/codex/tasks/task_e_689102f03ba0832d976aedbf01141093