### PR TITLE
Validate cleanup paths and handle worker failures

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
@@ -601,8 +601,7 @@ class ScannerViewModel(
                     }
                     WorkInfo.State.FAILED -> {
                         dataStore.clearScannerCleanWorkId()
-                        delay(RESULT_DELAY_MS)
-                        cleanOperationHandler.resetAfterError()
+                        cleanOperationHandler.onCleaningFailed()
                     }
                     WorkInfo.State.CANCELLED -> {
                         dataStore.clearScannerCleanWorkId()


### PR DESCRIPTION
## Summary
- ensure only existing file paths are enqueued for deletion
- surface worker failures immediately with a clear error state and snackbar
- add worker-side validation and logging for missing or invalid paths

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68911766a0fc832d995374a491c2dd64