### PR TITLE
Improve error logging for file cleanup

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/work/FileCleanupWorker.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/work/FileCleanupWorker.kt
@@ -135,8 +135,12 @@ class FileCleanupWorker(
             when (val res = performAction(action, listOf(file))) {
                 is DataState.Error -> {
                     failedPaths += file.absolutePath
-                    println("FileCleanupWorker ---> ERROR deleting ${file.absolutePath} → reason = ${res.error}")
-                    Log.w(TAG, "Failed to process ${file.absolutePath}: ${res.error}")
+                    val reason = when (val err = res.error) {
+                        is Errors.Custom -> err.message
+                        else -> err.toString()
+                    }
+                    println("FileCleanupWorker ---> ERROR deleting ${file.absolutePath} → reason = $reason")
+                    Log.w(TAG, "Failed to process ${file.absolutePath}: $reason")
                 }
                 else -> {
                     successCount++

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/domain/model/network/Errors.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/domain/model/network/Errors.kt
@@ -4,6 +4,14 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Error
 
 sealed interface Errors : Error {
 
+    /**
+     * Generic error used when a more specific type is not available. It carries
+     * the original message so that it can be logged for debugging purposes.
+     */
+    data class Custom(val message: String? = null) : Errors {
+        override fun toString(): String = message ?: "Unknown error"
+    }
+
     enum class Network : Errors {
         REQUEST_TIMEOUT, NO_INTERNET, SERVER_ERROR, SERIALIZATION
     }

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/extensions/Errors.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/extensions/Errors.kt
@@ -34,6 +34,10 @@ fun Throwable.toError(default: Errors = Errors.UseCase.NO_DATA): Errors {
             else -> Errors.UseCase.FAILED_TO_ENCRYPT_CART
         }
 
-        else -> default
+        else -> if (default == Errors.UseCase.NO_DATA) {
+            Errors.Custom(this.message)
+        } else {
+            default
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `Errors.Custom` to carry detailed messages
- map unexpected throwables to `Errors.Custom`
- log detailed error messages in `FileCleanupWorker`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689121b03e64832da2908829760b5316