### PR TITLE
Improve deletion fallback and close analyze screen

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
@@ -598,6 +598,7 @@ class ScannerViewModel(
                             )
                         }
                         onEvent(ScannerEvent.RefreshData)
+                        onCloseAnalyzeComposable()
                     }
                     WorkInfo.State.FAILED -> {
                         dataStore.clearScannerCleanWorkId()


### PR DESCRIPTION
## Summary
- try native deletion first and fall back to SAF with detailed logs
- close analyze screen automatically once cleaning is done
- reuse the same deletion flow for WhatsApp cleaner

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891282b43d8832da4418e337cb3ecc0