### PR TITLE
Accumulate and report WhatsApp deletion results

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/domain/model/DeleteResult.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/domain/model/DeleteResult.kt
@@ -1,0 +1,6 @@
+package com.d4rk.cleaner.app.clean.whatsapp.summary.domain.model
+
+data class DeleteResult(
+    val deletedCount: Int,
+    val failedPaths: List<String>
+)

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/domain/repository/WhatsAppCleanerRepository.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/domain/repository/WhatsAppCleanerRepository.kt
@@ -1,10 +1,11 @@
 package com.d4rk.cleaner.app.clean.whatsapp.summary.domain.repository
 
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.model.WhatsAppMediaSummary
+import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.model.DeleteResult
 import java.io.File
 
 interface WhatsAppCleanerRepository {
     suspend fun getMediaSummary(): WhatsAppMediaSummary
     suspend fun listMediaFiles(type: String, offset: Int, limit: Int): List<File>
-    suspend fun deleteFiles(files: List<File>)
+    suspend fun deleteFiles(files: List<File>): DeleteResult
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/domain/usecases/DeleteWhatsAppMediaUseCase.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/domain/usecases/DeleteWhatsAppMediaUseCase.kt
@@ -2,6 +2,7 @@ package com.d4rk.cleaner.app.clean.whatsapp.summary.domain.usecases
 
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.repository.WhatsAppCleanerRepository
+import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.model.DeleteResult
 import com.d4rk.cleaner.core.domain.model.network.Errors
 import com.d4rk.cleaner.core.utils.extensions.toError
 import kotlinx.coroutines.flow.Flow
@@ -9,9 +10,9 @@ import kotlinx.coroutines.flow.flow
 import java.io.File
 
 class DeleteWhatsAppMediaUseCase(private val repository: WhatsAppCleanerRepository) {
-    operator fun invoke(files: List<File>): Flow<DataState<Unit, Errors>> = flow {
+    operator fun invoke(files: List<File>): Flow<DataState<DeleteResult, Errors>> = flow {
         runCatching { repository.deleteFiles(files) }
-            .onSuccess { emit(DataState.Success(Unit)) }
+            .onSuccess { emit(DataState.Success(it)) }
             .onFailure { emit(DataState.Error(error = it.toError())) }
     }
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsappCleanerSummaryViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsappCleanerSummaryViewModel.kt
@@ -82,20 +82,35 @@ class WhatsappCleanerSummaryViewModel(
             }
 
             deleteUseCase(files).collectLatest { result ->
-                val freed = files.sumOf { it.length() }
-                if (result is DataState.Success) {
-                    sendAction(
-                        WhatsAppCleanerAction.ShowSnackbar(
-                            UiSnackbar(
-                                message = UiTextHelper.DynamicString(
-                                    "Cleaned ${FileSizeFormatter.format(freed)}"
+                when (result) {
+                    is DataState.Success -> {
+                        val failed = result.data.failedPaths
+                        val freed = files.filterNot { it.path in failed }.sumOf { it.length() }
+                        val message = buildString {
+                            append("Cleaned ${FileSizeFormatter.format(freed)}")
+                            if (failed.isNotEmpty()) append(", ${failed.size} failed")
+                        }
+                        sendAction(
+                            WhatsAppCleanerAction.ShowSnackbar(
+                                UiSnackbar(message = UiTextHelper.DynamicString(message))
+                            )
+                        )
+                        CleaningEventBus.notifyCleaned(success = failed.isEmpty())
+                    }
+                    is DataState.Error -> {
+                        sendAction(
+                            WhatsAppCleanerAction.ShowSnackbar(
+                                UiSnackbar(
+                                    message = UiTextHelper.DynamicString("${result.error}"),
+                                    isError = true
                                 )
                             )
                         )
-                    )
+                        CleaningEventBus.notifyCleaned(success = false)
+                    }
+                    else -> Unit
                 }
                 onEvent(WhatsAppCleanerEvent.LoadMedia)
-                CleaningEventBus.notifyCleaned(success = true)
             }
         }
     }
@@ -104,20 +119,35 @@ class WhatsappCleanerSummaryViewModel(
         if (files.isEmpty()) return
         launch(context = dispatchers.io) {
             deleteUseCase(files).collectLatest { result ->
-                val freed = files.sumOf { it.length() }
-                if (result is DataState.Success) {
-                    sendAction(
-                        WhatsAppCleanerAction.ShowSnackbar(
-                            UiSnackbar(
-                                message = UiTextHelper.DynamicString(
-                                    "Cleaned ${FileSizeFormatter.format(freed)}"
+                when (result) {
+                    is DataState.Success -> {
+                        val failed = result.data.failedPaths
+                        val freed = files.filterNot { it.path in failed }.sumOf { it.length() }
+                        val message = buildString {
+                            append("Cleaned ${FileSizeFormatter.format(freed)}")
+                            if (failed.isNotEmpty()) append(", ${failed.size} failed")
+                        }
+                        sendAction(
+                            WhatsAppCleanerAction.ShowSnackbar(
+                                UiSnackbar(message = UiTextHelper.DynamicString(message))
+                            )
+                        )
+                        CleaningEventBus.notifyCleaned(success = failed.isEmpty())
+                    }
+                    is DataState.Error -> {
+                        sendAction(
+                            WhatsAppCleanerAction.ShowSnackbar(
+                                UiSnackbar(
+                                    message = UiTextHelper.DynamicString("${result.error}"),
+                                    isError = true
                                 )
                             )
                         )
-                    )
+                        CleaningEventBus.notifyCleaned(success = false)
+                    }
+                    else -> Unit
                 }
                 onEvent(WhatsAppCleanerEvent.LoadMedia)
-                CleaningEventBus.notifyCleaned(success = true)
             }
         }
     }


### PR DESCRIPTION
## Summary
- return per-file deletion results instead of throwing
- report failures and success count to use case and view model
- add DeleteResult model

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68912fa4c738832db8c7b8dad603c1c6