### PR TITLE
Refactor file deletion to shared helper

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/data/WhatsAppCleanerRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/data/WhatsAppCleanerRepositoryImpl.kt
@@ -1,16 +1,14 @@
 package com.d4rk.cleaner.app.clean.whatsapp.summary.data
 
 import android.app.Application
-import android.os.Build
 import android.os.Environment
-import android.provider.DocumentsContract
 import android.text.format.Formatter
-import androidx.documentfile.provider.DocumentFile
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.model.DirectorySummary
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.model.WhatsAppMediaSummary
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.repository.WhatsAppCleanerRepository
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.model.DeleteResult
 import com.d4rk.cleaner.app.clean.whatsapp.utils.constants.WhatsAppMediaConstants
+import com.d4rk.cleaner.core.utils.helpers.FileDeletionHelper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -88,78 +86,13 @@ class WhatsAppCleanerRepositoryImpl(private val application: Application) :
     }
 
     override suspend fun deleteFiles(files: List<File>): DeleteResult = withContext(Dispatchers.IO) {
-        val androidDir = Environment.getExternalStorageDirectory().absolutePath + "/Android"
-        val failed = mutableListOf<String>()
-        var deletedCount = 0
-
-        files.forEach { file ->
-            if (!file.exists()) return@forEach
-
-            val hasManage =
-                Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && Environment.isExternalStorageManager()
-            var usingSaf = !hasManage ||
-                file.absolutePath.startsWith(androidDir) || !file.canWrite()
-            var deleted = false
-
-            if (!usingSaf) {
-                val success = file.deleteRecursively()
-                if (success) {
-                    println("Deletion method: Native → path: ${file.path}")
-                    deleted = true
-                } else {
-                    println("deleteRecursively failed for ${file.path}")
-                    usingSaf = true
-                    println("Fallback to SAF for ${file.path}")
-                }
-            }
-
-            if (usingSaf && !deleted) {
-                val result = deleteWithSaf(file)
-                println("Deletion method: SAF → path: ${file.path}")
-                println("DocumentFile.delete() success: $result for ${file.path}")
-                deleted = result
-            }
-
-            if (deleted) {
-                deletedCount++
-            } else {
-                failed.add(file.path)
-                println("Deletion failed for ${file.path}")
-            }
-        }
-
+        val results = FileDeletionHelper.deleteFiles(application, files)
+        val deletedCount = results.count { it.success }
+        val failed = results.filter { !it.success }.map { it.file.path }
         DeleteResult(
             deletedCount = deletedCount,
             failedPaths = failed
         )
-    }
-
-    private fun deleteWithSaf(target: File): Boolean {
-        val absPath = target.absolutePath
-        val base = Environment.getExternalStorageDirectory().absolutePath
-        val resolver = application.contentResolver
-        var document: DocumentFile? = null
-        var hasPermission = false
-        for (perm in resolver.persistedUriPermissions) {
-            val docId = DocumentsContract.getTreeDocumentId(perm.uri)
-            val rootPath = base + "/" + docId.substringAfter(':')
-            if (absPath.startsWith(rootPath)) {
-                hasPermission = true
-                var current = DocumentFile.fromTreeUri(application, perm.uri)
-                val relative = absPath.removePrefix(rootPath).trimStart('/')
-                if (relative.isNotEmpty()) {
-                    for (part in relative.split('/')) {
-                        current = current?.listFiles()?.firstOrNull { it.name == part }
-                        if (current == null) break
-                    }
-                }
-                document = current
-                break
-            }
-        }
-        println("FileCleanupWorker ---> SAF delete attempt for path: $absPath")
-        println("FileCleanupWorker ---> Found document: ${document != null} | hasPermission: $hasPermission")
-        return hasPermission && document?.delete() == true
     }
 
     override suspend fun listMediaFiles(type: String, offset: Int, limit: Int): List<File> =

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/FileDeletionHelper.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/FileDeletionHelper.kt
@@ -1,0 +1,90 @@
+package com.d4rk.cleaner.core.utils.helpers
+
+import android.app.Application
+import android.os.Build
+import android.os.Environment
+import android.provider.DocumentsContract
+import androidx.documentfile.provider.DocumentFile
+import java.io.File
+
+/**
+ * Deletes files using native deletion first and falling back to SAF when needed.
+ * Returns [FileDeletionResult] for each input file describing success or failure.
+ */
+data class FileDeletionResult(val file: File, val success: Boolean)
+
+object FileDeletionHelper {
+    fun deleteFiles(application: Application, files: Collection<File>): List<FileDeletionResult> {
+        val androidDir = Environment.getExternalStorageDirectory().absolutePath + "/Android"
+        val results = mutableListOf<FileDeletionResult>()
+
+        files.forEach { file ->
+            if (!file.exists()) {
+                results.add(FileDeletionResult(file, false))
+                return@forEach
+            }
+
+            val hasManage = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
+                Environment.isExternalStorageManager()
+            var usingSaf = !hasManage ||
+                file.absolutePath.startsWith(androidDir) || !file.canWrite()
+            var deleted = false
+
+            if (!usingSaf) {
+                val success = file.deleteRecursively()
+                if (success) {
+                    println("Deletion method: Native → path: ${file.path}")
+                    deleted = true
+                } else {
+                    println("deleteRecursively failed for ${file.path}")
+                    usingSaf = true
+                    println("Fallback to SAF for ${file.path}")
+                }
+            }
+
+            if (usingSaf && !deleted) {
+                val safResult = deleteWithSaf(application, file)
+                println("Deletion method: SAF → path: ${file.path}")
+                println("DocumentFile.delete() success: $safResult for ${file.path}")
+                deleted = safResult
+            }
+
+            if (!deleted) {
+                println("Deletion failed for ${file.path}")
+            }
+
+            results.add(FileDeletionResult(file, deleted))
+        }
+
+        return results
+    }
+
+    private fun deleteWithSaf(application: Application, target: File): Boolean {
+        val absPath = target.absolutePath
+        val base = Environment.getExternalStorageDirectory().absolutePath
+        val resolver = application.contentResolver
+        var document: DocumentFile? = null
+        var hasPermission = false
+        for (perm in resolver.persistedUriPermissions) {
+            val docId = DocumentsContract.getTreeDocumentId(perm.uri)
+            val rootPath = base + "/" + docId.substringAfter(':')
+            if (absPath.startsWith(rootPath)) {
+                hasPermission = true
+                var current = DocumentFile.fromTreeUri(application, perm.uri)
+                val relative = absPath.removePrefix(rootPath).trimStart('/')
+                if (relative.isNotEmpty()) {
+                    for (part in relative.split('/')) {
+                        current = current?.listFiles()?.firstOrNull { it.name == part }
+                        if (current == null) break
+                    }
+                }
+                document = current
+                break
+            }
+        }
+        println("FileCleanupWorker ---> SAF delete attempt for path: $absPath")
+        println("FileCleanupWorker ---> Found document: ${document != null} | hasPermission: $hasPermission")
+        return hasPermission && document?.delete() == true
+    }
+}
+


### PR DESCRIPTION
## Summary
- centralize native+SAF file deletion in new `FileDeletionHelper`
- reuse helper in scanner and WhatsApp repositories for per-file results

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689139e327cc832da427a86a779d7948