### PR TITLE
feat: add cleanup partial translations

### DIFF
--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -436,4 +436,5 @@
     <string name="cleanup_failed">فشل التنظيف</string>
     <string name="cleanup_failed_details">تعذر حذف بعض الملفات</string>
     <string name="cleanup_cancelled">تم إلغاء التنظيف</string>
+    <string name="cleanup_partial">تم حذف %1$d ملفًا، فشل حذف %2$d</string>
 </resources>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -403,4 +403,5 @@
     <string name="cleanup_failed">Почистването се провали</string>
     <string name="cleanup_failed_details">Някои файлове не можаха да бъдат изтрити</string>
     <string name="cleanup_cancelled">Почистването е отменено</string>
+    <string name="cleanup_partial">%1$d файла изтрити, %2$d неуспешни</string>
 </resources>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -403,4 +403,5 @@
     <string name="cleanup_failed">পরিষ্কার ব্যর্থ হয়েছে</string>
     <string name="cleanup_failed_details">কিছু ফাইল মুছে ফেলা যায়নি</string>
     <string name="cleanup_cancelled">পরিষ্কার বাতিল করা হয়েছে</string>
+    <string name="cleanup_partial">%1$d টি ফাইল মুছে ফেলা হয়েছে, %2$d টি ব্যর্থ হয়েছে</string>
 </resources>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -404,4 +404,5 @@
     <string name="cleanup_failed">Bereinigung fehlgeschlagen</string>
     <string name="cleanup_failed_details">Einige Dateien konnten nicht gelöscht werden</string>
     <string name="cleanup_cancelled">Bereinigung abgebrochen</string>
+    <string name="cleanup_partial">%1$d Dateien gelöscht, %2$d fehlgeschlagen</string>
 </resources>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -412,4 +412,5 @@
     <string name="cleanup_failed">Limpieza fallida</string>
     <string name="cleanup_failed_details">No se pudieron eliminar algunos archivos</string>
     <string name="cleanup_cancelled">Limpieza cancelada</string>
+    <string name="cleanup_partial">%1$d archivos eliminados, %2$d fallidos</string>
 </resources>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -412,4 +412,5 @@
     <string name="cleanup_failed">Limpieza fallida</string>
     <string name="cleanup_failed_details">No se pudieron eliminar algunos archivos</string>
     <string name="cleanup_cancelled">Limpieza cancelada</string>
+    <string name="cleanup_partial">%1$d archivos eliminados, %2$d fallidos</string>
 </resources>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -404,4 +404,5 @@
     <string name="cleanup_failed">Nabigo ang paglilinis</string>
     <string name="cleanup_failed_details">May ilang file na hindi matanggal</string>
     <string name="cleanup_cancelled">Kinansela ang paglilinis</string>
+    <string name="cleanup_partial">Na-delete ang %1$d na file, nabigo ang %2$d</string>
 </resources>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -413,4 +413,5 @@
     <string name="cleanup_failed">Échec du nettoyage</string>
     <string name="cleanup_failed_details">Certains fichiers n\'ont pas pu être supprimés</string>
     <string name="cleanup_cancelled">Nettoyage annulé</string>
+    <string name="cleanup_partial">%1$d fichiers supprimés, %2$d échoués</string>
 </resources>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -404,4 +404,5 @@
     <string name="cleanup_failed">सफाई असफल रही</string>
     <string name="cleanup_failed_details">कुछ फ़ाइलें हटाई नहीं जा सकीं</string>
     <string name="cleanup_cancelled">सफाई रद्द की गई</string>
+    <string name="cleanup_partial">%1$d फ़ाइलें हटाई गईं, %2$d असफल रहीं</string>
 </resources>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -404,4 +404,5 @@
     <string name="cleanup_failed">Tisztítás sikertelen</string>
     <string name="cleanup_failed_details">Néhány fájlt nem sikerült törölni</string>
     <string name="cleanup_cancelled">Tisztítás megszakítva</string>
+    <string name="cleanup_partial">%1$d fájl törölve, %2$d sikertelen</string>
 </resources>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -396,4 +396,5 @@
     <string name="cleanup_failed">Pembersihan gagal</string>
     <string name="cleanup_failed_details">Beberapa file tidak dapat dihapus</string>
     <string name="cleanup_cancelled">Pembersihan dibatalkan</string>
+    <string name="cleanup_partial">%1$d file dihapus, %2$d gagal</string>
 </resources>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -412,4 +412,5 @@
     <string name="cleanup_failed">Pulizia non riuscita</string>
     <string name="cleanup_failed_details">Impossibile eliminare alcuni file</string>
     <string name="cleanup_cancelled">Pulizia annullata</string>
+    <string name="cleanup_partial">%1$d file eliminati, %2$d non riusciti</string>
 </resources>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -396,4 +396,5 @@
     <string name="cleanup_failed">クリーンアップに失敗しました</string>
     <string name="cleanup_failed_details">一部のファイルを削除できませんでした</string>
     <string name="cleanup_cancelled">クリーンアップをキャンセルしました</string>
+    <string name="cleanup_partial">%1$d 件のファイルを削除、%2$d 件が失敗しました</string>
 </resources>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -396,4 +396,5 @@
     <string name="cleanup_failed">정리에 실패했습니다</string>
     <string name="cleanup_failed_details">일부 파일을 삭제할 수 없습니다</string>
     <string name="cleanup_cancelled">정리가 취소되었습니다</string>
+    <string name="cleanup_partial">%1$d개의 파일 삭제, %2$d개 실패</string>
 </resources>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -420,4 +420,5 @@
     <string name="cleanup_failed">Czyszczenie nie powiodło się</string>
     <string name="cleanup_failed_details">Niektórych plików nie można było usunąć</string>
     <string name="cleanup_cancelled">Czyszczenie anulowane</string>
+    <string name="cleanup_partial">%1$d plików usunięto, %2$d nie powiodło się</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -412,4 +412,5 @@
     <string name="cleanup_failed">Falha na limpeza</string>
     <string name="cleanup_failed_details">Alguns arquivos não puderam ser excluídos</string>
     <string name="cleanup_cancelled">Limpeza cancelada</string>
+    <string name="cleanup_partial">%1$d arquivos excluídos, %2$d falharam</string>
 </resources>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -412,4 +412,5 @@
     <string name="cleanup_failed">Curățare eșuată</string>
     <string name="cleanup_failed_details">Unele fișiere nu au putut fi șterse</string>
     <string name="cleanup_cancelled">Curățare anulată</string>
+    <string name="cleanup_partial">%1$d fișiere șterse, %2$d eșuate</string>
 </resources>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -420,4 +420,5 @@
     <string name="cleanup_failed">Очистка не удалась</string>
     <string name="cleanup_failed_details">Некоторые файлы не удалось удалить</string>
     <string name="cleanup_cancelled">Очистка отменена</string>
+    <string name="cleanup_partial">%1$d файлов удалено, %2$d не удалось</string>
 </resources>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -404,4 +404,5 @@
     <string name="cleanup_failed">Rensning misslyckades</string>
     <string name="cleanup_failed_details">Vissa filer kunde inte tas bort</string>
     <string name="cleanup_cancelled">Rensning avbruten</string>
+    <string name="cleanup_partial">%1$d filer raderades, %2$d misslyckades</string>
 </resources>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -396,4 +396,5 @@
     <string name="cleanup_failed">การล้างล้มเหลว</string>
     <string name="cleanup_failed_details">ไม่สามารถลบไฟล์บางไฟล์ได้</string>
     <string name="cleanup_cancelled">ยกเลิกการล้าง</string>
+    <string name="cleanup_partial">ลบไฟล์ %1$d ไฟล์แล้ว, ล้มเหลว %2$d ไฟล์</string>
 </resources>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -404,4 +404,5 @@
     <string name="cleanup_failed">Temizlik başarısız</string>
     <string name="cleanup_failed_details">Bazı dosyalar silinemedi</string>
     <string name="cleanup_cancelled">Temizlik iptal edildi</string>
+    <string name="cleanup_partial">%1$d dosya silindi, %2$d başarısız oldu</string>
 </resources>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -420,4 +420,5 @@
     <string name="cleanup_failed">Очищення не вдалося</string>
     <string name="cleanup_failed_details">Деякі файли не вдалося видалити</string>
     <string name="cleanup_cancelled">Очищення скасовано</string>
+    <string name="cleanup_partial">Видалено %1$d файлів, %2$d не вдалося</string>
 </resources>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -404,4 +404,5 @@
     <string name="cleanup_failed">صفائی ناکام</string>
     <string name="cleanup_failed_details">کچھ فائلیں حذف نہیں ہو سکیں</string>
     <string name="cleanup_cancelled">صفائی منسوخ کی گئی</string>
+    <string name="cleanup_partial">%1$d فائلیں حذف ہوئیں، %2$d ناکام ہوئیں</string>
 </resources>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -396,4 +396,5 @@
     <string name="cleanup_failed">Dọn dẹp thất bại</string>
     <string name="cleanup_failed_details">Không thể xóa một số tệp</string>
     <string name="cleanup_cancelled">Đã hủy dọn dẹp</string>
+    <string name="cleanup_partial">%1$d tệp đã xóa, %2$d thất bại</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -396,4 +396,5 @@
     <string name="cleanup_failed">清理失敗</string>
     <string name="cleanup_failed_details">部分檔案無法刪除</string>
     <string name="cleanup_cancelled">清理已取消</string>
+    <string name="cleanup_partial">已刪除 %1$d 個檔案，%2$d 個失敗</string>
 </resources>


### PR DESCRIPTION
## Summary
- translate cleanup status `cleanup_partial` across 25 locales

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891b2939b1c832d884839369d6cf3da