### PR TITLE
Handle trash cleanup with WorkManager

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/trash/domain/data/model/ui/UiTrashModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/trash/domain/data/model/ui/UiTrashModel.kt
@@ -1,5 +1,6 @@
 package com.d4rk.cleaner.app.clean.trash.domain.data.model.ui
 
+import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.CleaningState
 import java.io.File
 
 data class UiTrashModel(
@@ -10,4 +11,5 @@ data class UiTrashModel(
     val selectedFileCount: Int = 0,
     val trashSize: Long = 0L,
     val trashFileOriginalPaths: Set<String> = emptySet(),
+    val cleaningState: CleaningState = CleaningState.Idle,
 )

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/trash/ui/TrashScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/trash/ui/TrashScreen.kt
@@ -25,6 +25,7 @@ import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.cleaner.R
 import com.d4rk.cleaner.app.clean.analyze.ui.components.FilesByDateSection
 import com.d4rk.cleaner.app.clean.scanner.ui.components.TwoRowButtons
+import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.CleaningState
 import com.d4rk.cleaner.app.clean.trash.domain.actions.TrashEvent
 import com.d4rk.cleaner.app.clean.trash.domain.data.model.ui.UiTrashModel
 import org.koin.compose.viewmodel.koinViewModel
@@ -56,7 +57,9 @@ fun TrashScreen(activity: TrashActivity) {
                     .padding(paddingValues)
             ) {
                 val (list, buttons) = createRefs()
-                val enabled = trashModel.selectedFileCount > 0
+                val enabled = trashModel.selectedFileCount > 0 &&
+                    trashModel.cleaningState != CleaningState.Cleaning &&
+                    trashModel.cleaningState != CleaningState.Error
 
                 TrashItemsList(
                     modifier = Modifier.constrainAs(list) {

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/data/datastore/DataStore.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/data/datastore/DataStore.kt
@@ -120,6 +120,24 @@ class DataStore(val context: Context) : CommonDataStore(context = context) {
         }
     }
 
+    private val trashCleanWorkIdKey =
+        stringPreferencesKey(AppDataStoreConstants.DATA_STORE_TRASH_CLEAN_WORK_ID)
+    val trashCleanWorkId: Flow<String?> = dataStore.data.map { prefs ->
+        prefs[trashCleanWorkIdKey]
+    }
+
+    suspend fun saveTrashCleanWorkId(id: String) {
+        dataStore.edit { prefs ->
+            prefs[trashCleanWorkIdKey] = id
+        }
+    }
+
+    suspend fun clearTrashCleanWorkId() {
+        dataStore.edit { prefs ->
+            prefs.remove(trashCleanWorkIdKey)
+        }
+    }
+
 
     private val trashFileOriginalPathsKey =
         stringSetPreferencesKey(AppDataStoreConstants.DATA_STORE_TRASH_FILE_ORIGINAL_PATHS)

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/di/modules/AppModule.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/di/modules/AppModule.kt
@@ -224,12 +224,13 @@ val appModule: Module = module {
     single<GetEmptyFoldersUseCase> { GetEmptyFoldersUseCase(repository = get()) }
     viewModel<TrashViewModel> {
         TrashViewModel(
+            application = get(),
             getTrashFilesUseCase = get(),
-            deleteFilesUseCase = get(),
             updateTrashSizeUseCase = get(),
             restoreFromTrashUseCase = get(),
             dispatchers = get(),
-            dataStore = get()
+            dataStore = get(),
+            fileCleanWorkEnqueuer = get(),
         )
     }
 

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/constants/datastore/AppDataStoreConstants.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/constants/datastore/AppDataStoreConstants.kt
@@ -40,4 +40,5 @@ object AppDataStoreConstants : DataStoreNamesConstants() {
     const val DATA_STORE_AUTO_CLEAN_FREQUENCY_DAYS = "auto_clean_frequency_days"
     const val DATA_STORE_SCANNER_CLEAN_WORK_ID = "scanner_clean_work_id"
     const val DATA_STORE_LARGE_FILES_CLEAN_WORK_ID = "large_files_clean_work_id"
+    const val DATA_STORE_TRASH_CLEAN_WORK_ID = "trash_clean_work_id"
 }


### PR DESCRIPTION
## Summary
- enqueue FileCleanupWorker for trash deletions and track job id in DataStore
- watch WorkManager for progress and report partial results via UI state
- expose CleaningState in trash screen and disable actions while cleaning or when errors occur

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891c2b9a594832dbd635d13d6ee0ca3