### PR TITLE
Track WhatsApp cleaning state and enqueue deletions

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/WhatsAppDetailsScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/WhatsAppDetailsScreen.kt
@@ -81,6 +81,7 @@ import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.model.UiWhatsAppCleane
 import com.d4rk.cleaner.app.clean.whatsapp.summary.ui.WhatsappCleanerSummaryViewModel
 import com.d4rk.cleaner.app.clean.whatsapp.utils.constants.WhatsAppMediaConstants
 import com.d4rk.cleaner.app.clean.whatsapp.utils.helpers.openFile
+import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.CleaningState
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 import org.koin.core.qualifier.named
@@ -301,7 +302,9 @@ fun DetailsScreen(
                                 .align(Alignment.CenterHorizontally)
                                 .padding(8.dp),
                             onClick = { showConfirm = true },
-                            enabled = selected.isNotEmpty(),
+                            enabled = selected.isNotEmpty() &&
+                                state.data?.cleaningState != CleaningState.Cleaning &&
+                                state.data?.cleaningState != CleaningState.Error,
                             iconContentDescription = null,
                             label = stringResource(id = R.string.delete_selected),
                             icon = Icons.Outlined.Delete
@@ -502,6 +505,8 @@ private fun SmartSuggestionsCard(
                     onShowConfirmChange(true)
                 },
                 modifier = Modifier.align(Alignment.End),
+                enabled = state.data?.cleaningState != CleaningState.Cleaning &&
+                    state.data?.cleaningState != CleaningState.Error,
                 label = stringResource(id = R.string.delete_all_suggested),
                 icon = Icons.Outlined.Delete
             )

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/domain/model/WhatsAppMediaSummary.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/domain/model/WhatsAppMediaSummary.kt
@@ -1,5 +1,7 @@
 package com.d4rk.cleaner.app.clean.whatsapp.summary.domain.model
 
+import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.CleaningState
+
 data class WhatsAppMediaSummary(
     val images: DirectorySummary = DirectorySummary(),
     val videos: DirectorySummary = DirectorySummary(),
@@ -34,4 +36,5 @@ data class WhatsAppMediaSummary(
 data class UiWhatsAppCleanerModel(
     val mediaSummary: WhatsAppMediaSummary = WhatsAppMediaSummary(),
     val totalSize: String = mediaSummary.formattedTotalSize,
+    val cleaningState: CleaningState = CleaningState.Idle,
 )

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsappCleanerSummaryScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsappCleanerSummaryScreen.kt
@@ -47,6 +47,7 @@ import com.d4rk.cleaner.app.clean.whatsapp.summary.ui.components.CleanerInfoCard
 import com.d4rk.cleaner.app.clean.whatsapp.summary.ui.components.DirectoryGrid
 import com.d4rk.cleaner.app.clean.whatsapp.summary.ui.components.WhatsAppEmptyState
 import com.d4rk.cleaner.app.clean.whatsapp.utils.constants.WhatsAppMediaConstants
+import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.CleaningState
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.qualifier.named
@@ -76,6 +77,8 @@ fun WhatsappCleanerSummaryScreen(activity: Activity) {
             AnimatedExtendedFloatingActionButton(
                 visible = state.data?.mediaSummary?.totalBytes != 0L,
                 onClick = { showCleanDialog = true },
+                enabled = state.data?.cleaningState != CleaningState.Cleaning &&
+                    state.data?.cleaningState != CleaningState.Error,
                 icon = {
                     Icon(
                         imageVector = Icons.Outlined.DeleteSweep,

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/data/datastore/DataStore.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/data/datastore/DataStore.kt
@@ -120,6 +120,24 @@ class DataStore(val context: Context) : CommonDataStore(context = context) {
         }
     }
 
+    private val whatsappCleanWorkIdKey =
+        stringPreferencesKey(AppDataStoreConstants.DATA_STORE_WHATSAPP_CLEAN_WORK_ID)
+    val whatsappCleanWorkId: Flow<String?> = dataStore.data.map { prefs ->
+        prefs[whatsappCleanWorkIdKey]
+    }
+
+    suspend fun saveWhatsAppCleanWorkId(id: String) {
+        dataStore.edit { prefs ->
+            prefs[whatsappCleanWorkIdKey] = id
+        }
+    }
+
+    suspend fun clearWhatsAppCleanWorkId() {
+        dataStore.edit { prefs ->
+            prefs.remove(whatsappCleanWorkIdKey)
+        }
+    }
+
     private val trashCleanWorkIdKey =
         stringPreferencesKey(AppDataStoreConstants.DATA_STORE_TRASH_CLEAN_WORK_ID)
     val trashCleanWorkId: Flow<String?> = dataStore.data.map { prefs ->

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/di/modules/AppModule.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/di/modules/AppModule.kt
@@ -59,7 +59,6 @@ import com.d4rk.cleaner.app.clean.trash.ui.TrashViewModel
 import com.d4rk.cleaner.app.clean.whatsapp.details.ui.DetailsViewModel
 import com.d4rk.cleaner.app.clean.whatsapp.summary.data.WhatsAppCleanerRepositoryImpl
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.repository.WhatsAppCleanerRepository
-import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.usecases.DeleteWhatsAppMediaUseCase
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.usecases.GetWhatsAppMediaFilesUseCase
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.usecases.GetWhatsAppMediaSummaryUseCase
 import com.d4rk.cleaner.app.clean.whatsapp.summary.ui.WhatsappCleanerSummaryViewModel
@@ -161,14 +160,15 @@ val appModule: Module = module {
 
     single<WhatsAppCleanerRepository> { WhatsAppCleanerRepositoryImpl(get()) }
     single { GetWhatsAppMediaSummaryUseCase(repository = get()) }
-    single { DeleteWhatsAppMediaUseCase(repository = get()) }
     single { GetWhatsAppMediaFilesUseCase(repository = get()) }
     viewModel {
         WhatsappCleanerSummaryViewModel(
+            application = get(),
             getSummaryUseCase = get(),
-            deleteUseCase = get(),
             getFilesUseCase = get(),
-            dispatchers = get()
+            dataStore = get(),
+            dispatchers = get(),
+            fileCleanWorkEnqueuer = get()
         )
     }
     viewModel { DetailsViewModel(dataStore = get(), dispatchers = get(), getFilesUseCase = get()) }

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/constants/datastore/AppDataStoreConstants.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/constants/datastore/AppDataStoreConstants.kt
@@ -41,4 +41,5 @@ object AppDataStoreConstants : DataStoreNamesConstants() {
     const val DATA_STORE_SCANNER_CLEAN_WORK_ID = "scanner_clean_work_id"
     const val DATA_STORE_LARGE_FILES_CLEAN_WORK_ID = "large_files_clean_work_id"
     const val DATA_STORE_TRASH_CLEAN_WORK_ID = "trash_clean_work_id"
+    const val DATA_STORE_WHATSAPP_CLEAN_WORK_ID = "whatsapp_clean_work_id"
 }


### PR DESCRIPTION
## Summary
- Add `CleaningState` to WhatsApp cleaner UI model and disable actions while cleaning or in error
- Persist WhatsApp cleanup work and observe WorkManager to surface partial failures
- Store cleanup work IDs in DataStore and wire ViewModel through DI

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891d038acd0832dab7d370c33f97564