### PR TITLE
feat: add extension for selected file paths

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/largefiles/ui/LargeFilesViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/largefiles/ui/LargeFilesViewModel.kt
@@ -19,6 +19,7 @@ import com.d4rk.cleaner.app.clean.scanner.domain.usecases.GetLargestFilesUseCase
 import com.d4rk.cleaner.app.clean.scanner.work.FileCleanupWorker
 import com.d4rk.cleaner.core.data.datastore.DataStore
 import com.d4rk.cleaner.core.utils.helpers.FileGroupingHelper
+import com.d4rk.cleaner.core.utils.extensions.selectedFiles
 import com.d4rk.cleaner.core.work.FileCleanWorkEnqueuer
 import com.d4rk.cleaner.core.work.FileCleaner
 import com.d4rk.cleaner.core.work.WorkObserver
@@ -118,9 +119,7 @@ class LargeFilesViewModel(
 
     private fun deleteSelected() {
         launch(context = dispatchers.io) {
-            val filePaths =
-                _uiState.value.data?.fileSelectionStates?.filter { it.value }?.keys ?: emptySet()
-            val files = filePaths.map { File(it) }.toSet()
+            val files = _uiState.value.data?.fileSelectionStates.selectedFiles()
             if (files.isEmpty()) {
                 sendAction(
                     LargeFilesAction.ShowSnackbar(
@@ -134,7 +133,7 @@ class LargeFilesViewModel(
 
             FileCleaner.enqueue(
                 enqueuer = fileCleanWorkEnqueuer,
-                paths = filePaths.toList(),
+                paths = files.map { it.absolutePath },
                 action = FileCleanupWorker.ACTION_DELETE,
                 getWorkId = { dataStore.largeFilesCleanWorkId.first() },
                 saveWorkId = { dataStore.saveLargeFilesCleanWorkId(it) },

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/CleanOperationHandler.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/CleanOperationHandler.kt
@@ -20,6 +20,7 @@ import com.d4rk.cleaner.app.settings.cleaning.utils.constants.ExtensionsConstant
 import com.d4rk.cleaner.core.data.datastore.DataStore
 import com.d4rk.cleaner.core.domain.model.network.Errors
 import com.d4rk.cleaner.core.utils.helpers.FileGroupingHelper
+import com.d4rk.cleaner.core.utils.extensions.selectedFiles
 import com.d4rk.cleaner.core.work.FileCleanWorkEnqueuer
 import com.d4rk.cleaner.core.work.FileCleaner
 import kotlinx.coroutines.CoroutineScope
@@ -166,13 +167,9 @@ class CleanOperationHandler(
             return
         }
 
-        val selectedPaths: Set<String> = currentScreenData.analyzeState.selectedFiles
-        val filesToDelete: Set<File> = selectedPaths
-            .mapNotNull { path ->
-                path.takeIf { it.isNotBlank() }?.let { File(it) }
-            }
-            .filter { it.exists() }
-            .toSet()
+        val filesToDelete = currentScreenData.analyzeState.selectedFiles
+            .associateWith { true }
+            .selectedFiles()
         if (filesToDelete.isEmpty()) {
             postSnackbar(UiTextHelper.StringResource(R.string.no_files_selected_to_clean), false)
             return

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/extensions/SelectionExtensions.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/extensions/SelectionExtensions.kt
@@ -1,0 +1,22 @@
+package com.d4rk.cleaner.core.utils.extensions
+
+import java.io.File
+
+/**
+ * Converts a map of file path selections into a set of existing [File]s.
+ *
+ * Only entries with a `true` value are considered. Null maps or paths
+ * pointing to non-existent files are ignored.
+ *
+ * Example:
+ * ```
+ * val files: Set<File> = state.fileSelectionStates.selectedFiles()
+ * ```
+ */
+fun Map<String, Boolean>?.selectedFiles(): Set<File> {
+    return this?.mapNotNull { (path, isSelected) ->
+        if (!isSelected || path.isBlank()) return@mapNotNull null
+        File(path).takeIf { it.exists() }
+    }?.toSet() ?: emptySet()
+}
+


### PR DESCRIPTION
## Summary
- add Map<String, Boolean>.selectedFiles() extension
- use selectedFiles() in LargeFilesViewModel, TrashViewModel and CleanOperationHandler

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68925a6b3bcc832d93e15eb923d8e68d