### PR TITLE
Remove SAF-based deletion fallback

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/data/ScannerRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/data/ScannerRepositoryImpl.kt
@@ -149,7 +149,7 @@ class ScannerRepositoryImpl(
     }
 
     override suspend fun deleteFiles(files: Collection<File>): Unit {
-        val results = FileDeletionHelper.deleteFiles(application, files)
+        val results = FileDeletionHelper.deleteFiles(files)
         val totalSize = results.filter { it.success }.sumOf { it.file.length() }
         if (results.any { !it.success }) {
             throw RuntimeException("SAF_DELETE_FAILED")

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/data/WhatsAppCleanerRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/data/WhatsAppCleanerRepositoryImpl.kt
@@ -86,7 +86,7 @@ class WhatsAppCleanerRepositoryImpl(private val application: Application) :
     }
 
     override suspend fun deleteFiles(files: Collection<File>): DeleteResult = withContext(Dispatchers.IO) {
-        val results = FileDeletionHelper.deleteFiles(application, files)
+        val results = FileDeletionHelper.deleteFiles(files)
         val deletedCount = results.count { it.success }
         val failed = results.filter { !it.success }.map { it.file.path }
         DeleteResult(

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/extensions/FileExtensions.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/extensions/FileExtensions.kt
@@ -51,3 +51,7 @@ fun File.partialMd5(): String? = runCatching {
 
     md.digest().joinToString("") { "%02x".format(it) }
 }.getOrNull()
+
+fun File.deleteRecursivelySafe(): Boolean = runCatching {
+    deleteRecursively()
+}.getOrDefault(false)

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/FileDeletionHelper.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/FileDeletionHelper.kt
@@ -1,90 +1,28 @@
 package com.d4rk.cleaner.core.utils.helpers
 
-import android.app.Application
-import android.os.Build
-import android.os.Environment
-import android.provider.DocumentsContract
-import androidx.documentfile.provider.DocumentFile
+import com.d4rk.cleaner.core.utils.extensions.deleteRecursivelySafe
 import java.io.File
 
 /**
- * Deletes files using native deletion first and falling back to SAF when needed.
+ * Deletes files using a single safe recursive delete call.
  * Returns [FileDeletionResult] for each input file describing success or failure.
  */
 data class FileDeletionResult(val file: File, val success: Boolean)
 
 object FileDeletionHelper {
-    fun deleteFiles(application: Application, files: Collection<File>): List<FileDeletionResult> {
-        val androidDir = Environment.getExternalStorageDirectory().absolutePath + "/Android"
+    fun deleteFiles(files: Collection<File>): List<FileDeletionResult> {
         val results = mutableListOf<FileDeletionResult>()
 
         files.forEach { file ->
-            if (!file.exists()) {
-                results.add(FileDeletionResult(file, false))
-                return@forEach
+            val deleted = if (file.exists()) {
+                file.deleteRecursivelySafe()
+            } else {
+                false
             }
-
-            val hasManage = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
-                Environment.isExternalStorageManager()
-            var usingSaf = !hasManage ||
-                file.absolutePath.startsWith(androidDir) || !file.canWrite()
-            var deleted = false
-
-            if (!usingSaf) {
-                val success = file.deleteRecursively()
-                if (success) {
-                    println("Deletion method: Native → path: ${file.path}")
-                    deleted = true
-                } else {
-                    println("deleteRecursively failed for ${file.path}")
-                    usingSaf = true
-                    println("Fallback to SAF for ${file.path}")
-                }
-            }
-
-            if (usingSaf && !deleted) {
-                val safResult = deleteWithSaf(application, file)
-                println("Deletion method: SAF → path: ${file.path}")
-                println("DocumentFile.delete() success: $safResult for ${file.path}")
-                deleted = safResult
-            }
-
-            if (!deleted) {
-                println("Deletion failed for ${file.path}")
-            }
-
             results.add(FileDeletionResult(file, deleted))
         }
 
         return results
-    }
-
-    private fun deleteWithSaf(application: Application, target: File): Boolean {
-        val absPath = target.absolutePath
-        val base = Environment.getExternalStorageDirectory().absolutePath
-        val resolver = application.contentResolver
-        var document: DocumentFile? = null
-        var hasPermission = false
-        for (perm in resolver.persistedUriPermissions) {
-            val docId = DocumentsContract.getTreeDocumentId(perm.uri)
-            val rootPath = base + "/" + docId.substringAfter(':')
-            if (absPath.startsWith(rootPath)) {
-                hasPermission = true
-                var current = DocumentFile.fromTreeUri(application, perm.uri)
-                val relative = absPath.removePrefix(rootPath).trimStart('/')
-                if (relative.isNotEmpty()) {
-                    for (part in relative.split('/')) {
-                        current = current?.listFiles()?.firstOrNull { it.name == part }
-                        if (current == null) break
-                    }
-                }
-                document = current
-                break
-            }
-        }
-        println("FileCleanupWorker ---> SAF delete attempt for path: $absPath")
-        println("FileCleanupWorker ---> Found document: ${document != null} | hasPermission: $hasPermission")
-        return hasPermission && document?.delete() == true
     }
 }
 


### PR DESCRIPTION
## Summary
- Drop DocumentFile-based SAF fallback from `FileDeletionHelper`
- Add `deleteRecursivelySafe` extension and use it for file deletions
- Adjust repositories to call simplified helper

## Testing
- `./gradlew test` *(fails: SDK location not found. Tried installing android-sdk but ca-certificates-java failed)*

------
https://chatgpt.com/codex/tasks/task_e_689263f22a9c832d9c47b65a74378d5f