### PR TITLE
Remove SAF deletion branch and surface file delete failures

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/data/ScannerRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/data/ScannerRepositoryImpl.kt
@@ -151,8 +151,10 @@ class ScannerRepositoryImpl(
     override suspend fun deleteFiles(files: Collection<File>): Unit {
         val results = FileDeletionHelper.deleteFiles(files)
         val totalSize = results.filter { it.success }.sumOf { it.file.length() }
-        if (results.any { !it.success }) {
-            throw RuntimeException("SAF_DELETE_FAILED")
+        val failed = results.filter { !it.success }
+        if (failed.isNotEmpty()) {
+            val paths = failed.joinToString { it.file.absolutePath }
+            throw RuntimeException("FILE_DELETE_FAILED: $paths")
         }
         if (totalSize > 0) {
             dataStore.addCleanedSpace(space = totalSize)

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/extensions/FileExtensions.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/extensions/FileExtensions.kt
@@ -52,6 +52,3 @@ fun File.partialMd5(): String? = runCatching {
     md.digest().joinToString("") { "%02x".format(it) }
 }.getOrNull()
 
-fun File.deleteRecursivelySafe(): Boolean = runCatching {
-    deleteRecursively()
-}.getOrDefault(false)

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/FileDeletionHelper.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/FileDeletionHelper.kt
@@ -1,10 +1,9 @@
 package com.d4rk.cleaner.core.utils.helpers
 
-import com.d4rk.cleaner.core.utils.extensions.deleteRecursivelySafe
 import java.io.File
 
 /**
- * Deletes files using a single safe recursive delete call.
+ * Deletes files using native [File.deleteRecursively].
  * Returns [FileDeletionResult] for each input file describing success or failure.
  */
 data class FileDeletionResult(val file: File, val success: Boolean)
@@ -14,11 +13,9 @@ object FileDeletionHelper {
         val results = mutableListOf<FileDeletionResult>()
 
         files.forEach { file ->
-            val deleted = if (file.exists()) {
-                file.deleteRecursivelySafe()
-            } else {
-                false
-            }
+            val deleted = runCatching {
+                if (file.exists()) file.deleteRecursively() else false
+            }.getOrDefault(false)
             results.add(FileDeletionResult(file, deleted))
         }
 


### PR DESCRIPTION
## Summary
- Simplify file deletion to use native `File.deleteRecursively` and capture failures
- Remove `deleteRecursivelySafe` extension and `SAF_DELETE_FAILED` messaging
- Propagate failed deletions from `ScannerRepositoryImpl`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689277e56e5c832d89769640bff6f194