### PR TITLE
Refactor file clean work observation into reusable helper

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/largefiles/ui/LargeFilesViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/largefiles/ui/LargeFilesViewModel.kt
@@ -21,9 +21,8 @@ import com.d4rk.cleaner.core.utils.extensions.selectedFiles
 import com.d4rk.cleaner.core.utils.helpers.FileGroupingHelper
 import com.d4rk.cleaner.core.work.FileCleanWorkEnqueuer
 import com.d4rk.cleaner.core.work.FileCleaner
-import com.d4rk.cleaner.core.work.WorkObserver
+import com.d4rk.cleaner.core.work.observeFileCleanWork
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
@@ -144,12 +143,11 @@ class LargeFilesViewModel(
         }
     }
     private fun observeWork(id: UUID) {
-        activeWorkObserver?.cancel()
-        activeWorkObserver = WorkObserver.observe(
-            scope = MainScope(),
-            workManager = WorkManager.getInstance(application),
-            workId = id,
+        activeWorkObserver = observeFileCleanWork(
+            previousObserver = activeWorkObserver,
+            application = application,
             dispatcher = dispatchers.io,
+            workId = id,
             clearWorkId = { dataStore.clearLargeFilesCleanWorkId() },
             onRunning = {
                 _uiState.update { it.copy(screenState = ScreenState.IsLoading()) }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/trash/ui/TrashViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/trash/ui/TrashViewModel.kt
@@ -24,10 +24,9 @@ import com.d4rk.cleaner.core.utils.extensions.selectedFiles
 import com.d4rk.cleaner.core.utils.helpers.FileGroupingHelper
 import com.d4rk.cleaner.core.work.FileCleanWorkEnqueuer
 import com.d4rk.cleaner.core.work.FileCleaner
-import com.d4rk.cleaner.core.work.WorkObserver
+import com.d4rk.cleaner.core.work.observeFileCleanWork
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
@@ -69,12 +68,11 @@ class TrashViewModel(
     }
 
     private fun observeWork(id: UUID) {
-        activeWorkObserver?.cancel()
-        activeWorkObserver = WorkObserver.observe(
-            scope = MainScope(),
-            workManager = WorkManager.getInstance(application),
-            workId = id,
+        activeWorkObserver = observeFileCleanWork(
+            previousObserver = activeWorkObserver,
+            application = application,
             dispatcher = dispatchers.io,
+            workId = id,
             clearWorkId = { dataStore.clearTrashCleanWorkId() },
             onRunning = {
                 _uiState.update {

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsappCleanerSummaryViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsappCleanerSummaryViewModel.kt
@@ -23,9 +23,8 @@ import com.d4rk.cleaner.core.utils.helpers.CleaningEventBus
 import com.d4rk.cleaner.core.utils.helpers.FileSizeFormatter
 import com.d4rk.cleaner.core.work.FileCleanWorkEnqueuer
 import com.d4rk.cleaner.core.work.FileCleaner
-import com.d4rk.cleaner.core.work.WorkObserver
+import com.d4rk.cleaner.core.work.observeFileCleanWork
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
@@ -201,12 +200,11 @@ class WhatsappCleanerSummaryViewModel(
     }
 
     private fun observeWork(id: UUID) {
-        activeWorkObserver?.cancel()
-        activeWorkObserver = WorkObserver.observe(
-            scope = MainScope(),
-            workManager = WorkManager.getInstance(application),
-            workId = id,
+        activeWorkObserver = observeFileCleanWork(
+            previousObserver = activeWorkObserver,
+            application = application,
             dispatcher = dispatchers.io,
+            workId = id,
             clearWorkId = { dataStore.clearWhatsAppCleanWorkId() },
             onRunning = {
                 _uiState.update {

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/work/FileCleanWorkObserver.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/work/FileCleanWorkObserver.kt
@@ -1,0 +1,41 @@
+package com.d4rk.cleaner.core.work
+
+import android.app.Application
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.MainScope
+import java.util.UUID
+
+/**
+ * Observes a [WorkManager] file clean work and relays state changes through callbacks.
+ *
+ * Cancels any previously active observer before registering a new one to avoid
+ * leaking collectors. Internally delegates to [WorkObserver.observe].
+ */
+fun observeFileCleanWork(
+    previousObserver: Job?,
+    application: Application,
+    dispatcher: CoroutineDispatcher,
+    workId: UUID,
+    clearWorkId: suspend () -> Unit,
+    onRunning: suspend () -> Unit = {},
+    onSuccess: suspend (WorkInfo) -> Unit = {},
+    onFailed: suspend () -> Unit = {},
+    onCancelled: suspend () -> Unit = {},
+): Job {
+    previousObserver?.cancel()
+    return WorkObserver.observe(
+        scope = MainScope(),
+        workManager = WorkManager.getInstance(application),
+        workId = workId,
+        dispatcher = dispatcher,
+        clearWorkId = clearWorkId,
+        onRunning = onRunning,
+        onSuccess = onSuccess,
+        onFailed = onFailed,
+        onCancelled = onCancelled,
+    )
+}
+


### PR DESCRIPTION
## Summary
- add observeFileCleanWork helper to centralize WorkManager state observation
- refactor TrashViewModel, LargeFilesViewModel, and WhatsappCleanerSummaryViewModel to use the helper

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68927a0312b4832da661ab4b132579e7