### PR TITLE
docs: describe file cleaner lifecycle

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ This directory contains technical and product documentation for the Smart Cleane
 ## Table of Contents
 - [Cleaning Screens and Flows](cleaning_screens.md)
 - [Cleanup Job System](cleanup_jobs.md)
+- [File Cleaner Lifecycle](cleaner_lifecycle.md)
 - [Clipboard Cleaner](clipboard_cleaner.md)
 - [Empty Folder Cleaner](empty_folder_cleaner.md)
 - [Trash Recovery](trash_recovery.md)

--- a/docs/cleaner_lifecycle.md
+++ b/docs/cleaner_lifecycle.md
@@ -1,0 +1,42 @@
+# File Cleaner Lifecycle
+
+This document explains how file-cleaning requests move through Smart Cleaner's work pipeline and how UI components observe the resulting work.
+
+## Pipeline Overview
+1. **`FileCleaner.enqueue`** – UI helper that prevents duplicate jobs, shows standard feedback and delegates to the work enqueuer.
+2. **`FileCleanWorkEnqueuer.enqueue`** – Chunks file paths, enqueues `FileCleanupWorker` instances and persists the `WorkRequest` ID.
+3. **`FileCleanupWorker.doWork`** – Iterates over each file, updates the progress notification and dispatches success or failure events.
+4. **`CleaningManager.deleteFiles`** – Coordinates deletion or trash moves.
+5. **`DeleteFilesUseCase`** – Executes the actual delete or move-to-trash operation on the repository.
+
+## Result Structure and Observer Utility
+* `FileCleanupWorker` returns a `Result` whose `outputData` may contain `KEY_FAILED_PATHS`, an array of file paths that could not be processed. Callers can read it via `info.outputData.getStringArray(FileCleanupWorker.KEY_FAILED_PATHS)` to surface partial failures.
+* The `observeFileCleanWork` helper cancels any previous observer, attaches to the stored work ID, and triggers callbacks for running, success, failure, or cancellation while clearing the ID when finished.
+
+## Work ID Persistence
+```mermaid
+sequenceDiagram
+    participant UI
+    participant Enqueuer
+    participant DataStore
+    participant Observer
+    UI->>Enqueuer: FileCleaner.enqueue(paths)
+    Enqueuer->>DataStore: save(workId)
+    Observer->>DataStore: read(workId)
+    Observer->>WorkManager: observe(workId)
+    WorkManager-->>Observer: state updates
+    Observer->>DataStore: clear()
+```
+
+## Notification Updates
+* Worker shows a determinate progress notification (`n/N files cleaned`).
+* After each file, progress is updated.
+* On completion the notification is replaced with success, partial, or failure text and is dismissed after a short delay.
+
+## `CleaningEventBus` Callbacks
+* `FileCleanupWorker` publishes `notifyCleaned(success: Boolean)` when work ends.
+* Subscribers (e.g., streak trackers or ViewModels) collect `CleaningEventBus.events` to refresh UI or statistics.
+
+## Further Reading
+* [Cleanup Job System](cleanup_jobs.md)
+* Feature docs such as [Empty Folder Cleaner](empty_folder_cleaner.md) and [Trash Recovery](trash_recovery.md)


### PR DESCRIPTION
## Summary
- document the file-cleaner pipeline from `FileCleaner.enqueue` down to `DeleteFilesUseCase`
- note `KEY_FAILED_PATHS` output and `observeFileCleanWork` helper
- add sequence flow and links to related cleanup docs

## Testing
- `ANDROID_HOME=/usr/lib/android-sdk ./gradlew test` *(fails: SDK packages not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68927d7aa7fc832da65fd3bf4fffa70c