### PR TITLE
Validate APK paths before deletion

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
@@ -811,9 +811,21 @@ class ScannerViewModel(
     }
 
     fun onCleanApks(apkFiles: List<File>) {
-        val entries =
-            apkFiles.map { FileEntry(it.absolutePath, it.length(), it.lastModified()) }.toSet()
-        deleteFiles(entries, fromApkCleaner = true)
+        val (validFiles, invalidFiles) = apkFiles.partition { it.exists() && it.canWrite() }
+
+        if (invalidFiles.isNotEmpty()) {
+            postSnackbar(
+                UiTextHelper.StringResource(R.string.cleanup_failed_details),
+                isError = true
+            )
+        }
+
+        val entries = validFiles
+            .map { FileEntry(it.absolutePath, it.length(), it.lastModified()) }
+            .toSet()
+        if (entries.isNotEmpty()) {
+            deleteFiles(entries, fromApkCleaner = true)
+        }
     }
 
     fun onCleanEmptyFolders(folders: List<File>) {


### PR DESCRIPTION
## Summary
- Validate APK files for existence and write permissions before cleaning
- Warn if any selected APK files are invalid
- Only delete files that pass validation

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689280e83da4832d9400ed4736375242