### PR TITLE
Add MediaStore fallback when deleting files

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/data/ScannerRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/data/ScannerRepositoryImpl.kt
@@ -149,7 +149,7 @@ class ScannerRepositoryImpl(
     }
 
     override suspend fun deleteFiles(files: Collection<File>): Unit {
-        val results = FileDeletionHelper.deleteFiles(files)
+        val results = FileDeletionHelper.deleteFiles(files, application.contentResolver)
         val totalSize = results.filter { it.success }.sumOf { it.file.length() }
         val failed = results.filter { !it.success }
         if (failed.isNotEmpty()) {

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/data/WhatsAppCleanerRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/data/WhatsAppCleanerRepositoryImpl.kt
@@ -86,7 +86,7 @@ class WhatsAppCleanerRepositoryImpl(private val application: Application) :
     }
 
     override suspend fun deleteFiles(files: Collection<File>): DeleteResult = withContext(Dispatchers.IO) {
-        val results = FileDeletionHelper.deleteFiles(files)
+        val results = FileDeletionHelper.deleteFiles(files, application.contentResolver)
         val deletedCount = results.count { it.success }
         val failed = results.filter { !it.success }.map { it.file.path }
         DeleteResult(

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/FileDeletionHelper.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/FileDeletionHelper.kt
@@ -1,5 +1,9 @@
 package com.d4rk.cleaner.core.utils.helpers
 
+import android.content.ContentResolver
+import android.content.ContentUris
+import android.os.Build
+import android.provider.MediaStore
 import java.io.File
 
 /**
@@ -9,17 +13,45 @@ import java.io.File
 data class FileDeletionResult(val file: File, val success: Boolean)
 
 object FileDeletionHelper {
-    fun deleteFiles(files: Collection<File>): List<FileDeletionResult> {
+    fun deleteFiles(files: Collection<File>, contentResolver: ContentResolver): List<FileDeletionResult> {
         val results = mutableListOf<FileDeletionResult>()
 
         files.forEach { file ->
-            val deleted = runCatching {
-                if (file.exists()) file.deleteRecursively() else false
+            val success = runCatching {
+                if (!file.exists()) {
+                    false
+                } else if (file.deleteRecursively()) {
+                    true
+                } else {
+                    val uri = resolveMediaStoreUri(file, contentResolver)
+                    uri != null && contentResolver.delete(uri, null, null) > 0
+                }
             }.getOrDefault(false)
-            results.add(FileDeletionResult(file, deleted))
+            results.add(FileDeletionResult(file, success))
         }
 
         return results
+    }
+
+    private fun resolveMediaStoreUri(file: File, contentResolver: ContentResolver) = run {
+        val volume = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            MediaStore.VOLUME_EXTERNAL
+        } else {
+            "external"
+        }
+        val collection = MediaStore.Files.getContentUri(volume)
+        val projection = arrayOf(MediaStore.Files.FileColumns._ID)
+        val selection = MediaStore.Files.FileColumns.DATA + "=?"
+        val selectionArgs = arrayOf(file.absolutePath)
+        contentResolver.query(collection, projection, selection, selectionArgs, null)?.use { cursor ->
+            if (cursor.moveToFirst()) {
+                val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Files.FileColumns._ID)
+                val id = cursor.getLong(idColumn)
+                ContentUris.withAppendedId(collection, id)
+            } else {
+                null
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- attempt MediaStore deletion via `ContentResolver` when `File.deleteRecursively()` fails
- pass app `ContentResolver` to `FileDeletionHelper` from callers

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892834c4d40832da40fcdf501516163