### PR TITLE
docs: add cleaning features overview

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ This directory contains technical and product documentation for the Smart Cleane
 ## Table of Contents
 - [Cleaning Screens and Flows](cleaning_screens.md)
 - [Cleanup Job System](cleanup_jobs.md)
+- [Cleaning Features Overview](cleaning_features.md)
 - [File Cleaner Lifecycle](cleaner_lifecycle.md)
 - [Clipboard Cleaner](clipboard_cleaner.md)
 - [Empty Folder Cleaner](empty_folder_cleaner.md)

--- a/docs/cleaning_features.md
+++ b/docs/cleaning_features.md
@@ -1,0 +1,31 @@
+# Cleaning Features Overview
+
+Smart Cleaner provides multiple cleaning modules built on a shared cleanup architecture. Each module runs WorkManager jobs without relying on the Storage Access Framework (SAF), ensuring a streamlined file-deletion flow.
+
+All cleanup jobs enqueue a `FileCleanupWorker` via the centralized [FileCleanWorkEnqueuer](../app/src/main/kotlin/com/d4rk/cleaner/core/work/FileCleanWorkEnqueuer.kt). Work request IDs for active jobs are stored in [DataStore](../app/src/main/kotlin/com/d4rk/cleaner/core/data/datastore/DataStore.kt) so each feature tracks its own progress.
+
+## WhatsApp Cleaner
+- Summaries and cleans WhatsApp media.
+- ViewModel: [WhatsappCleanerSummaryViewModel](../app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsappCleanerSummaryViewModel.kt)
+- Use cases: [GetWhatsAppMediaSummaryUseCase](../app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/domain/usecases/GetWhatsAppMediaSummaryUseCase.kt), [GetWhatsAppMediaFilesUseCase](../app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/domain/usecases/GetWhatsAppMediaFilesUseCase.kt)
+- Work ID key: `whatsappCleanWorkId`
+
+## Large Files Cleaner
+- Finds and deletes oversized files across storage.
+- ViewModel: [LargeFilesViewModel](../app/src/main/kotlin/com/d4rk/cleaner/app/clean/largefiles/ui/LargeFilesViewModel.kt)
+- Use case: [GetLargestFilesUseCase](../app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/domain/usecases/GetLargestFilesUseCase.kt)
+- Work ID key: `largeFilesCleanWorkId`
+
+## Trash
+- Handles user trash operations and recovery.
+- ViewModel: [TrashViewModel](../app/src/main/kotlin/com/d4rk/cleaner/app/clean/trash/ui/TrashViewModel.kt)
+- Use cases: [GetTrashFilesUseCase](../app/src/main/kotlin/com/d4rk/cleaner/app/clean/trash/domain/usecases/GetTrashFilesUseCase.kt), [RestoreFromTrashUseCase](../app/src/main/kotlin/com/d4rk/cleaner/app/clean/trash/domain/usecases/RestoreFromTrashUseCase.kt)
+- Work ID key: `trashCleanWorkId`
+
+## Dashboard
+- Entry point aggregating storage analysis and quick clean actions.
+- ViewModel: [ScannerViewModel](../app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt)
+- Use case: [AnalyzeFilesUseCase](../app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/domain/usecases/AnalyzeFilesUseCase.kt)
+- Work ID key: `scannerCleanWorkId`
+
+For details on the job lifecycle and WorkManager integration, see [Cleanup Job System](cleanup_jobs.md).


### PR DESCRIPTION
## Summary
- outline WhatsApp, Large Files, Trash, and Dashboard cleaners on top of the shared cleanup architecture
- document SAF-free design, unified WorkManager jobs, and feature-specific work IDs
- link each feature to its ViewModel and use cases for easy navigation

## Testing
- `./gradlew lint` *(fails: SDK location not found)*
- `apt-get install -y android-sdk` *(fails: ca-certificates-java error)*

------
https://chatgpt.com/codex/tasks/task_e_6892852aa138832db8601cc8258f6db8