### PR TITLE
Document WhatsApp clean work tracking

### DIFF
--- a/docs/cleaning_screens.md
+++ b/docs/cleaning_screens.md
@@ -48,13 +48,15 @@
 - Idle → Scanning individual WhatsApp directories → Displaying media categories → Cleaning.
 
 **State persistence**
-- Lists and selections live in memory; job IDs stored in `DataStore` reuse the general `scannerCleanWorkId` key.
+ - Lists and selections remain in memory; job IDs stored in `DataStore` under `whatsappCleanWorkId`.
+ - `FileCleaner.enqueue` schedules work, stores `whatsappCleanWorkId`, and prevents duplicate jobs.
+ - `observeFileCleanWork` reads that ID to report progress and surface per-file failures from worker output.
 
 **Error handling**
 - Scan or delete failures show snackbars; media lists fall back to empty results.
 
 **System events**
-- Process death requires a rescan unless a job is running, in which case the UI reattaches using the stored ID.
+ - Because selections and lists are memory-only, process death forces a rescan unless a job is active; when active, `observeFileCleanWork` reattaches using the stored ID.
 
 ## 4. Large Files Scanner
 **Trigger**


### PR DESCRIPTION
## Summary
- Clarify that WhatsApp cleaner uses `whatsappCleanWorkId`
- Outline how `FileCleaner.enqueue` and `observeFileCleanWork` persist IDs, track progress, and report failures
- Note that WhatsApp selections live in memory and require a rescan after process death unless work is running

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892874dea4c832d9663ac868bc571a7