### PR TITLE
Skip cleanup of protected Android directories

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/AndroidDirHelper.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/AndroidDirHelper.kt
@@ -1,0 +1,20 @@
+package com.d4rk.cleaner.core.utils.helpers
+
+import java.io.File
+
+/**
+ * Returns true if this file is located under a protected Android directory
+ * such as `/Android/data` or `/Android/obb`.
+ */
+fun File.isProtectedAndroidDir(): Boolean {
+    val segments = absolutePath.split(File.separatorChar).filter { it.isNotEmpty() }
+    segments.forEachIndexed { index, segment ->
+        if (segment == "Android") {
+            val next = segments.getOrNull(index + 1)
+            if (next == "data" || next == "obb") {
+                return true
+            }
+        }
+    }
+    return false
+}


### PR DESCRIPTION
## Summary
- add `File.isProtectedAndroidDir` helper
- skip `/Android/data` and `/Android/obb` entries in `FileCleanupWorker`
- treat workers with only protected paths as successful

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892f11f340c832d8fbf64b4cb48a2f8