### PR TITLE
Filter protected Android directories

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/extensions/SelectionExtensions.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/extensions/SelectionExtensions.kt
@@ -1,6 +1,7 @@
 package com.d4rk.cleaner.core.utils.extensions
 
 import java.io.File
+import com.d4rk.cleaner.core.utils.helpers.isProtectedAndroidDir
 
 /**
  * Converts a map of file path selections into a set of existing [File]s.
@@ -16,7 +17,7 @@ import java.io.File
 fun Map<String, Boolean>?.selectedFiles(): Set<File> {
     return this?.mapNotNull { (path, isSelected) ->
         if (!isSelected || path.isBlank()) return@mapNotNull null
-        File(path).takeIf { it.exists() }
+        File(path).takeIf { it.exists() && !it.isProtectedAndroidDir() }
     }?.toSet() ?: emptySet()
 }
 

--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -428,7 +428,7 @@
     <string name="data_not_available">البيانات غير متوفرة.</string>
     <string name="feature_not_available">الميزة غير متوفرة بعد.</string>
     <string name="no_files_selected_to_clean">لم يتم تحديد ملفات لتنظيف.</string>
-    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
+    <string name="protected_android_folder">هذا المجلد محمي ولا يمكن تنظيفه.</string>
     <string name="failed_to_update_trash_size">فشل في تحديث حجم القمامة: %1$s</string>
     <string name="no_cleaning_options_selected">يرجى اختيار تفضيلات التنظيف الخاصة بك في الإعدادات للمتابعة.</string>
     <string name="cleaning_in_progress">جاري التنظيف</string>

--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -428,6 +428,7 @@
     <string name="data_not_available">البيانات غير متوفرة.</string>
     <string name="feature_not_available">الميزة غير متوفرة بعد.</string>
     <string name="no_files_selected_to_clean">لم يتم تحديد ملفات لتنظيف.</string>
+    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
     <string name="failed_to_update_trash_size">فشل في تحديث حجم القمامة: %1$s</string>
     <string name="no_cleaning_options_selected">يرجى اختيار تفضيلات التنظيف الخاصة بك في الإعدادات للمتابعة.</string>
     <string name="cleaning_in_progress">جاري التنظيف</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -395,7 +395,7 @@
     <string name="data_not_available">Данните не са налични.</string>
     <string name="feature_not_available">Функцията все още не е налична.</string>
     <string name="no_files_selected_to_clean">Не са избрани файлове за почистване.</string>
-    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
+    <string name="protected_android_folder">Тази папка е защитена и не може да бъде почистена.</string>
     <string name="failed_to_update_trash_size">Неуспешно актуализиране на размера на боклука: %1$s</string>
     <string name="no_cleaning_options_selected">Моля, изберете вашите предпочитания за почистване в настройките, за да продължите.</string>
     <string name="cleaning_in_progress">Почистването е в ход</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -395,6 +395,7 @@
     <string name="data_not_available">Данните не са налични.</string>
     <string name="feature_not_available">Функцията все още не е налична.</string>
     <string name="no_files_selected_to_clean">Не са избрани файлове за почистване.</string>
+    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
     <string name="failed_to_update_trash_size">Неуспешно актуализиране на размера на боклука: %1$s</string>
     <string name="no_cleaning_options_selected">Моля, изберете вашите предпочитания за почистване в настройките, за да продължите.</string>
     <string name="cleaning_in_progress">Почистването е в ход</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -395,6 +395,7 @@
     <string name="data_not_available">ডেটা উপলভ্য নয়।</string>
     <string name="feature_not_available">ফিচারটি এখনও উপলভ্য নয়।</string>
     <string name="no_files_selected_to_clean">কোনও ফাইল পরিষ্কার করার জন্য নির্বাচিত নয়।</string>
+    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
     <string name="failed_to_update_trash_size">আবর্জনার আকার আপডেট করতে ব্যর্থ: %1$s</string>
     <string name="no_cleaning_options_selected">এগিয়ে যেতে সেটিংসে আপনার পরিষ্কারের পছন্দগুলি চয়ন করুন।</string>
     <string name="cleaning_in_progress">পরিষ্কার চলছে</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -395,7 +395,7 @@
     <string name="data_not_available">ডেটা উপলভ্য নয়।</string>
     <string name="feature_not_available">ফিচারটি এখনও উপলভ্য নয়।</string>
     <string name="no_files_selected_to_clean">কোনও ফাইল পরিষ্কার করার জন্য নির্বাচিত নয়।</string>
-    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
+    <string name="protected_android_folder">এই ফোল্ডারটি সুরক্ষিত এবং পরিষ্কার করা যাবে না।</string>
     <string name="failed_to_update_trash_size">আবর্জনার আকার আপডেট করতে ব্যর্থ: %1$s</string>
     <string name="no_cleaning_options_selected">এগিয়ে যেতে সেটিংসে আপনার পরিষ্কারের পছন্দগুলি চয়ন করুন।</string>
     <string name="cleaning_in_progress">পরিষ্কার চলছে</string>

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="protected_android_folder">Tato složka je chráněna a nelze ji vyčistit.</string>
+</resources>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -396,6 +396,7 @@
     <string name="data_not_available">Daten nicht verfügbar.</string>
     <string name="feature_not_available">Funktion noch nicht verfügbar.</string>
     <string name="no_files_selected_to_clean">Keine zum Reinigen ausgewählten Dateien.</string>
+    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
     <string name="failed_to_update_trash_size">Die Müllgröße nicht aktualisieren: %1$s</string>
     <string name="no_cleaning_options_selected">Bitte wählen Sie Ihre Reinigungseinstellungen in Einstellungen, um fortzufahren.</string>
     <string name="cleaning_in_progress">Reinigung läuft</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -396,7 +396,7 @@
     <string name="data_not_available">Daten nicht verfügbar.</string>
     <string name="feature_not_available">Funktion noch nicht verfügbar.</string>
     <string name="no_files_selected_to_clean">Keine zum Reinigen ausgewählten Dateien.</string>
-    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
+    <string name="protected_android_folder">Dieser Ordner ist geschützt und kann nicht bereinigt werden.</string>
     <string name="failed_to_update_trash_size">Die Müllgröße nicht aktualisieren: %1$s</string>
     <string name="no_cleaning_options_selected">Bitte wählen Sie Ihre Reinigungseinstellungen in Einstellungen, um fortzufahren.</string>
     <string name="cleaning_in_progress">Reinigung läuft</string>

--- a/app/src/main/res/values-el-rGR/strings.xml
+++ b/app/src/main/res/values-el-rGR/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="protected_android_folder">Αυτός ο φάκελος είναι προστατευμένος και δεν μπορεί να καθαριστεί.</string>
+</resources>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="protected_android_folder">Esta carpeta está protegida y no se puede limpiar.</string>
+</resources>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -404,7 +404,7 @@
     <string name="data_not_available">Datos no disponibles.</string>
     <string name="feature_not_available">Función aún no disponible.</string>
     <string name="no_files_selected_to_clean">No hay archivos seleccionados para limpiar.</string>
-    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
+    <string name="protected_android_folder">Esta carpeta está protegida y no se puede limpiar.</string>
     <string name="failed_to_update_trash_size">No se pudo actualizar el tamaño de la basura: %1$s</string>
     <string name="no_cleaning_options_selected">Elija sus preferencias de limpieza en Configuración para continuar.</string>
     <string name="cleaning_in_progress">Limpieza en curso</string>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -404,6 +404,7 @@
     <string name="data_not_available">Datos no disponibles.</string>
     <string name="feature_not_available">Función aún no disponible.</string>
     <string name="no_files_selected_to_clean">No hay archivos seleccionados para limpiar.</string>
+    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
     <string name="failed_to_update_trash_size">No se pudo actualizar el tamaño de la basura: %1$s</string>
     <string name="no_cleaning_options_selected">Elija sus preferencias de limpieza en Configuración para continuar.</string>
     <string name="cleaning_in_progress">Limpieza en curso</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -404,7 +404,7 @@
     <string name="data_not_available">Datos no disponibles.</string>
     <string name="feature_not_available">Función aún no disponible.</string>
     <string name="no_files_selected_to_clean">No hay archivos seleccionados para limpiar.</string>
-    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
+    <string name="protected_android_folder">Esta carpeta está protegida y no se puede limpiar.</string>
     <string name="failed_to_update_trash_size">No se pudo actualizar el tamaño de la basura: %1$s</string>
     <string name="no_cleaning_options_selected">Elija sus preferencias de limpieza en Configuración para continuar.</string>
     <string name="cleaning_in_progress">Limpieza en curso</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -404,6 +404,7 @@
     <string name="data_not_available">Datos no disponibles.</string>
     <string name="feature_not_available">Función aún no disponible.</string>
     <string name="no_files_selected_to_clean">No hay archivos seleccionados para limpiar.</string>
+    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
     <string name="failed_to_update_trash_size">No se pudo actualizar el tamaño de la basura: %1$s</string>
     <string name="no_cleaning_options_selected">Elija sus preferencias de limpieza en Configuración para continuar.</string>
     <string name="cleaning_in_progress">Limpieza en curso</string>

--- a/app/src/main/res/values-fa-rIR/strings.xml
+++ b/app/src/main/res/values-fa-rIR/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="protected_android_folder">این پوشه محافظت‌شده است و نمی‌توان آن را تمیز کرد.</string>
+</resources>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -396,6 +396,7 @@
     <string name="data_not_available">Hindi magagamit ang data.</string>
     <string name="feature_not_available">Hindi pa magagamit ang tampok.</string>
     <string name="no_files_selected_to_clean">Walang mga file na napili upang linisin.</string>
+    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
     <string name="failed_to_update_trash_size">Nabigong i -update ang laki ng basurahan: %1$s</string>
     <string name="no_cleaning_options_selected">Mangyaring piliin ang iyong mga kagustuhan sa paglilinis sa mga setting upang magpatuloy.</string>
     <string name="cleaning_in_progress">Isinasagawa ang paglilinis</string>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -396,7 +396,7 @@
     <string name="data_not_available">Hindi magagamit ang data.</string>
     <string name="feature_not_available">Hindi pa magagamit ang tampok.</string>
     <string name="no_files_selected_to_clean">Walang mga file na napili upang linisin.</string>
-    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
+    <string name="protected_android_folder">Protektado ang folder na ito at hindi maaaring linisin.</string>
     <string name="failed_to_update_trash_size">Nabigong i -update ang laki ng basurahan: %1$s</string>
     <string name="no_cleaning_options_selected">Mangyaring piliin ang iyong mga kagustuhan sa paglilinis sa mga setting upang magpatuloy.</string>
     <string name="cleaning_in_progress">Isinasagawa ang paglilinis</string>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -396,7 +396,7 @@
     <string name="data_not_available">Hindi magagamit ang data.</string>
     <string name="feature_not_available">Hindi pa magagamit ang tampok.</string>
     <string name="no_files_selected_to_clean">Walang mga file na napili upang linisin.</string>
-    <string name="protected_android_folder">Protektado ang folder na ito at hindi maaaring linisin.</string>
+    <string name="protected_android_folder">Ang folder na ito ay protektado at hindi maaaring linisin.</string>
     <string name="failed_to_update_trash_size">Nabigong i -update ang laki ng basurahan: %1$s</string>
     <string name="no_cleaning_options_selected">Mangyaring piliin ang iyong mga kagustuhan sa paglilinis sa mga setting upang magpatuloy.</string>
     <string name="cleaning_in_progress">Isinasagawa ang paglilinis</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -405,7 +405,7 @@
     <string name="data_not_available">Données non disponibles.</string>
     <string name="feature_not_available">Fonctionnalité pas encore disponible.</string>
     <string name="no_files_selected_to_clean">Aucun fichier sélectionné pour nettoyer.</string>
-    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
+    <string name="protected_android_folder">Ce dossier est protégé et ne peut pas être nettoyé.</string>
     <string name="failed_to_update_trash_size">Échec de la mise à jour de la taille des poubelles: %1$s</string>
     <string name="no_cleaning_options_selected">Veuillez choisir vos préférences de nettoyage dans les paramètres pour continuer.</string>
     <string name="cleaning_in_progress">Nettoyage en cours</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -405,6 +405,7 @@
     <string name="data_not_available">Données non disponibles.</string>
     <string name="feature_not_available">Fonctionnalité pas encore disponible.</string>
     <string name="no_files_selected_to_clean">Aucun fichier sélectionné pour nettoyer.</string>
+    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
     <string name="failed_to_update_trash_size">Échec de la mise à jour de la taille des poubelles: %1$s</string>
     <string name="no_cleaning_options_selected">Veuillez choisir vos préférences de nettoyage dans les paramètres pour continuer.</string>
     <string name="cleaning_in_progress">Nettoyage en cours</string>

--- a/app/src/main/res/values-he-rIL/strings.xml
+++ b/app/src/main/res/values-he-rIL/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="protected_android_folder">תיקייה זו מוגנת ולא ניתן לנקות אותה.</string>
+</resources>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -396,6 +396,7 @@
     <string name="data_not_available">डेटा उपलब्ध नहीं।</string>
     <string name="feature_not_available">फ़ीचर अभी उपलब्ध नहीं है।</string>
     <string name="no_files_selected_to_clean">कोई फाइलें साफ करने के लिए नहीं चुनी गईं।</string>
+    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
     <string name="failed_to_update_trash_size">कचरा आकार अपडेट करने में विफल: %1$s</string>
     <string name="no_cleaning_options_selected">कृपया आगे बढ़ने के लिए सेटिंग्स में अपनी सफाई वरीयताएँ चुनें।</string>
     <string name="cleaning_in_progress">सफाई जारी है</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -396,7 +396,7 @@
     <string name="data_not_available">डेटा उपलब्ध नहीं।</string>
     <string name="feature_not_available">फ़ीचर अभी उपलब्ध नहीं है।</string>
     <string name="no_files_selected_to_clean">कोई फाइलें साफ करने के लिए नहीं चुनी गईं।</string>
-    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
+    <string name="protected_android_folder">यह फ़ोल्डर सुरक्षित है और साफ़ नहीं किया जा सकता।</string>
     <string name="failed_to_update_trash_size">कचरा आकार अपडेट करने में विफल: %1$s</string>
     <string name="no_cleaning_options_selected">कृपया आगे बढ़ने के लिए सेटिंग्स में अपनी सफाई वरीयताएँ चुनें।</string>
     <string name="cleaning_in_progress">सफाई जारी है</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -396,7 +396,7 @@
     <string name="data_not_available">Az adatok nem állnak rendelkezésre.</string>
     <string name="feature_not_available">A funkció még nem elérhető.</string>
     <string name="no_files_selected_to_clean">A tisztításhoz nincs kiválasztott fájl.</string>
-    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
+    <string name="protected_android_folder">Ez a mappa védett, és nem tisztítható meg.</string>
     <string name="failed_to_update_trash_size">Nem sikerült frissíteni a szemét méretét: %1$s</string>
     <string name="no_cleaning_options_selected">Kérjük, válassza ki a tisztítási beállításokat a beállításokban.</string>
     <string name="cleaning_in_progress">Tisztítás folyamatban</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -396,6 +396,7 @@
     <string name="data_not_available">Az adatok nem állnak rendelkezésre.</string>
     <string name="feature_not_available">A funkció még nem elérhető.</string>
     <string name="no_files_selected_to_clean">A tisztításhoz nincs kiválasztott fájl.</string>
+    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
     <string name="failed_to_update_trash_size">Nem sikerült frissíteni a szemét méretét: %1$s</string>
     <string name="no_cleaning_options_selected">Kérjük, válassza ki a tisztítási beállításokat a beállításokban.</string>
     <string name="cleaning_in_progress">Tisztítás folyamatban</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -388,7 +388,7 @@
     <string name="data_not_available">Data tidak tersedia.</string>
     <string name="feature_not_available">Fitur belum tersedia.</string>
     <string name="no_files_selected_to_clean">Tidak ada file yang dipilih untuk dibersihkan.</string>
-    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
+    <string name="protected_android_folder">Folder ini dilindungi dan tidak dapat dibersihkan.</string>
     <string name="failed_to_update_trash_size">Gagal memperbarui ukuran sampah: %1$s</string>
     <string name="no_cleaning_options_selected">Pilih preferensi pembersihan Anda dalam pengaturan untuk melanjutkan.</string>
     <string name="cleaning_in_progress">Pembersihan sedang berlangsung</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -388,6 +388,7 @@
     <string name="data_not_available">Data tidak tersedia.</string>
     <string name="feature_not_available">Fitur belum tersedia.</string>
     <string name="no_files_selected_to_clean">Tidak ada file yang dipilih untuk dibersihkan.</string>
+    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
     <string name="failed_to_update_trash_size">Gagal memperbarui ukuran sampah: %1$s</string>
     <string name="no_cleaning_options_selected">Pilih preferensi pembersihan Anda dalam pengaturan untuk melanjutkan.</string>
     <string name="cleaning_in_progress">Pembersihan sedang berlangsung</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -404,7 +404,7 @@
     <string name="data_not_available">Dati non disponibili.</string>
     <string name="feature_not_available">Funzionalità non ancora disponibile.</string>
     <string name="no_files_selected_to_clean">Nessun file selezionato per pulire.</string>
-    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
+    <string name="protected_android_folder">Questa cartella è protetta e non può essere pulita.</string>
     <string name="failed_to_update_trash_size">Impossibile aggiornare la dimensione della spazzatura: %1$s</string>
     <string name="no_cleaning_options_selected">Scegli le tue preferenze di pulizia nelle impostazioni per procedere.</string>
     <string name="cleaning_in_progress">Pulizia in corso</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -404,6 +404,7 @@
     <string name="data_not_available">Dati non disponibili.</string>
     <string name="feature_not_available">Funzionalità non ancora disponibile.</string>
     <string name="no_files_selected_to_clean">Nessun file selezionato per pulire.</string>
+    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
     <string name="failed_to_update_trash_size">Impossibile aggiornare la dimensione della spazzatura: %1$s</string>
     <string name="no_cleaning_options_selected">Scegli le tue preferenze di pulizia nelle impostazioni per procedere.</string>
     <string name="cleaning_in_progress">Pulizia in corso</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -388,6 +388,7 @@
     <string name="data_not_available">データは利用できません。</string>
     <string name="feature_not_available">機能はまだ利用できません。</string>
     <string name="no_files_selected_to_clean">クリーニングするために選択されたファイルはありません。</string>
+    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
     <string name="failed_to_update_trash_size">ゴミのサイズの更新に失敗しました：%1$s</string>
     <string name="no_cleaning_options_selected">続行するには、設定のクリーニング設定を選択してください。</string>
     <string name="cleaning_in_progress">クリーンアップを実行中</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -388,7 +388,7 @@
     <string name="data_not_available">データは利用できません。</string>
     <string name="feature_not_available">機能はまだ利用できません。</string>
     <string name="no_files_selected_to_clean">クリーニングするために選択されたファイルはありません。</string>
-    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
+    <string name="protected_android_folder">このフォルダは保護されているため、クリーンアップできません。</string>
     <string name="failed_to_update_trash_size">ゴミのサイズの更新に失敗しました：%1$s</string>
     <string name="no_cleaning_options_selected">続行するには、設定のクリーニング設定を選択してください。</string>
     <string name="cleaning_in_progress">クリーンアップを実行中</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -388,7 +388,7 @@
     <string name="data_not_available">데이터를 사용할 수 없습니다.</string>
     <string name="feature_not_available">기능을 아직 사용할 수 없습니다.</string>
     <string name="no_files_selected_to_clean">청소할 파일이 없습니다.</string>
-    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
+    <string name="protected_android_folder">이 폴더는 보호되어 있어 청소할 수 없습니다.</string>
     <string name="failed_to_update_trash_size">쓰레기 크기를 업데이트하지 못했습니다 : %1$s</string>
     <string name="no_cleaning_options_selected">진행할 설정에서 청소 환경 설정을 선택하십시오.</string>
     <string name="cleaning_in_progress">정리 진행 중</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -388,6 +388,7 @@
     <string name="data_not_available">데이터를 사용할 수 없습니다.</string>
     <string name="feature_not_available">기능을 아직 사용할 수 없습니다.</string>
     <string name="no_files_selected_to_clean">청소할 파일이 없습니다.</string>
+    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
     <string name="failed_to_update_trash_size">쓰레기 크기를 업데이트하지 못했습니다 : %1$s</string>
     <string name="no_cleaning_options_selected">진행할 설정에서 청소 환경 설정을 선택하십시오.</string>
     <string name="cleaning_in_progress">정리 진행 중</string>

--- a/app/src/main/res/values-ms-rMY/strings.xml
+++ b/app/src/main/res/values-ms-rMY/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="protected_android_folder">Folder ini dilindungi dan tidak boleh dibersihkan.</string>
+</resources>

--- a/app/src/main/res/values-nl-rNL/strings.xml
+++ b/app/src/main/res/values-nl-rNL/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="protected_android_folder">Deze map is beschermd en kan niet worden opgeschoond.</string>
+</resources>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -412,6 +412,7 @@
     <string name="data_not_available">Dane niedostępne.</string>
     <string name="feature_not_available">Funkcja jest jeszcze niedostępna.</string>
     <string name="no_files_selected_to_clean">Brak plików do czyszczenia.</string>
+    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
     <string name="failed_to_update_trash_size">Nie udało się zaktualizować rozmiaru śmieci: %1$s</string>
     <string name="no_cleaning_options_selected">Wybierz swoje preferencje czyszczące w ustawieniach, aby kontynuować.</string>
     <string name="cleaning_in_progress">Trwa czyszczenie</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -412,7 +412,7 @@
     <string name="data_not_available">Dane niedostępne.</string>
     <string name="feature_not_available">Funkcja jest jeszcze niedostępna.</string>
     <string name="no_files_selected_to_clean">Brak plików do czyszczenia.</string>
-    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
+    <string name="protected_android_folder">Ten folder jest chroniony i nie można go wyczyścić.</string>
     <string name="failed_to_update_trash_size">Nie udało się zaktualizować rozmiaru śmieci: %1$s</string>
     <string name="no_cleaning_options_selected">Wybierz swoje preferencje czyszczące w ustawieniach, aby kontynuować.</string>
     <string name="cleaning_in_progress">Trwa czyszczenie</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -404,6 +404,7 @@
     <string name="data_not_available">Dados não disponíveis.</string>
     <string name="feature_not_available">Recurso ainda não disponível.</string>
     <string name="no_files_selected_to_clean">Nenhum arquivo selecionado para limpar.</string>
+    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
     <string name="failed_to_update_trash_size">Falha ao atualizar o tamanho do lixo: %1$s</string>
     <string name="no_cleaning_options_selected">Escolha suas preferências de limpeza nas configurações para prosseguir.</string>
     <string name="cleaning_in_progress">Limpeza em andamento</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -404,7 +404,7 @@
     <string name="data_not_available">Dados não disponíveis.</string>
     <string name="feature_not_available">Recurso ainda não disponível.</string>
     <string name="no_files_selected_to_clean">Nenhum arquivo selecionado para limpar.</string>
-    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
+    <string name="protected_android_folder">Esta pasta é protegida e não pode ser limpa.</string>
     <string name="failed_to_update_trash_size">Falha ao atualizar o tamanho do lixo: %1$s</string>
     <string name="no_cleaning_options_selected">Escolha suas preferências de limpeza nas configurações para prosseguir.</string>
     <string name="cleaning_in_progress">Limpeza em andamento</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="protected_android_folder">Esta pasta está protegida e não pode ser limpa.</string>
+</resources>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -404,6 +404,7 @@
     <string name="data_not_available">Datele nu sunt disponibile.</string>
     <string name="feature_not_available">Funcția nu este disponibilă încă.</string>
     <string name="no_files_selected_to_clean">Nu există fișiere selectate pentru a curăța.</string>
+    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
     <string name="failed_to_update_trash_size">Nu a reușit să actualizeze dimensiunea gunoiului: %1$s</string>
     <string name="no_cleaning_options_selected">Vă rugăm să alegeți preferințele dvs. de curățare în setări pentru a continua.</string>
     <string name="cleaning_in_progress">Curățare în curs</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -404,7 +404,7 @@
     <string name="data_not_available">Datele nu sunt disponibile.</string>
     <string name="feature_not_available">Funcția nu este disponibilă încă.</string>
     <string name="no_files_selected_to_clean">Nu există fișiere selectate pentru a curăța.</string>
-    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
+    <string name="protected_android_folder">Acest folder este protejat și nu poate fi curățat.</string>
     <string name="failed_to_update_trash_size">Nu a reușit să actualizeze dimensiunea gunoiului: %1$s</string>
     <string name="no_cleaning_options_selected">Vă rugăm să alegeți preferințele dvs. de curățare în setări pentru a continua.</string>
     <string name="cleaning_in_progress">Curățare în curs</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -412,6 +412,7 @@
     <string name="data_not_available">Данные недоступны.</string>
     <string name="feature_not_available">Функция пока недоступна.</string>
     <string name="no_files_selected_to_clean">Нет файлов, выбранных для очистки.</string>
+    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
     <string name="failed_to_update_trash_size">Не удалось обновить размер мусора: %1$s</string>
     <string name="no_cleaning_options_selected">Пожалуйста, выберите свои предпочтения в уборке в настройках, чтобы продолжить.</string>
     <string name="cleaning_in_progress">Идет очистка</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -412,7 +412,7 @@
     <string name="data_not_available">Данные недоступны.</string>
     <string name="feature_not_available">Функция пока недоступна.</string>
     <string name="no_files_selected_to_clean">Нет файлов, выбранных для очистки.</string>
-    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
+    <string name="protected_android_folder">Эта папка защищена и не может быть очищена.</string>
     <string name="failed_to_update_trash_size">Не удалось обновить размер мусора: %1$s</string>
     <string name="no_cleaning_options_selected">Пожалуйста, выберите свои предпочтения в уборке в настройках, чтобы продолжить.</string>
     <string name="cleaning_in_progress">Идет очистка</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -396,7 +396,7 @@
     <string name="data_not_available">Data inte tillgängliga.</string>
     <string name="feature_not_available">Funktionen är inte tillgänglig än.</string>
     <string name="no_files_selected_to_clean">Inga filer valda för att rengöra.</string>
-    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
+    <string name="protected_android_folder">Den här mappen är skyddad och kan inte rensas.</string>
     <string name="failed_to_update_trash_size">Det gick inte att uppdatera skräpstorlek: %1$s</string>
     <string name="no_cleaning_options_selected">Välj dina rengöringspreferenser i inställningar för att fortsätta.</string>
     <string name="cleaning_in_progress">Rensning pågår</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -396,6 +396,7 @@
     <string name="data_not_available">Data inte tillgängliga.</string>
     <string name="feature_not_available">Funktionen är inte tillgänglig än.</string>
     <string name="no_files_selected_to_clean">Inga filer valda för att rengöra.</string>
+    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
     <string name="failed_to_update_trash_size">Det gick inte att uppdatera skräpstorlek: %1$s</string>
     <string name="no_cleaning_options_selected">Välj dina rengöringspreferenser i inställningar för att fortsätta.</string>
     <string name="cleaning_in_progress">Rensning pågår</string>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -388,7 +388,7 @@
     <string name="data_not_available">ข้อมูลไม่พร้อมใช้งาน</string>
     <string name="feature_not_available">ฟีเจอร์ยังไม่พร้อมใช้งาน</string>
     <string name="no_files_selected_to_clean">ไม่มีไฟล์ที่เลือกเพื่อทำความสะอาด</string>
-    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
+    <string name="protected_android_folder">โฟลเดอร์นี้ได้รับการป้องกันและไม่สามารถทำความสะอาดได้</string>
     <string name="failed_to_update_trash_size">ไม่สามารถอัปเดตขนาดถังขยะ: %1$s</string>
     <string name="no_cleaning_options_selected">โปรดเลือกการตั้งค่าการทำความสะอาดของคุณในการตั้งค่าเพื่อดำเนินการต่อ</string>
     <string name="cleaning_in_progress">กำลังทำความสะอาด</string>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -388,6 +388,7 @@
     <string name="data_not_available">ข้อมูลไม่พร้อมใช้งาน</string>
     <string name="feature_not_available">ฟีเจอร์ยังไม่พร้อมใช้งาน</string>
     <string name="no_files_selected_to_clean">ไม่มีไฟล์ที่เลือกเพื่อทำความสะอาด</string>
+    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
     <string name="failed_to_update_trash_size">ไม่สามารถอัปเดตขนาดถังขยะ: %1$s</string>
     <string name="no_cleaning_options_selected">โปรดเลือกการตั้งค่าการทำความสะอาดของคุณในการตั้งค่าเพื่อดำเนินการต่อ</string>
     <string name="cleaning_in_progress">กำลังทำความสะอาด</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -396,7 +396,7 @@
     <string name="data_not_available">Veriler mevcut değil.</string>
     <string name="feature_not_available">Özellik henüz kullanılamıyor.</string>
     <string name="no_files_selected_to_clean">Temizlemek için dosya seçilmedi.</string>
-    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
+    <string name="protected_android_folder">Bu klasör korumalıdır ve temizlenemez.</string>
     <string name="failed_to_update_trash_size">Çöp Boyutunu Güncelleme: %1$s</string>
     <string name="no_cleaning_options_selected">Lütfen devam etmek için ayarlarda temizlik tercihlerinizi seçin.</string>
     <string name="cleaning_in_progress">Temizlik devam ediyor</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -396,6 +396,7 @@
     <string name="data_not_available">Veriler mevcut değil.</string>
     <string name="feature_not_available">Özellik henüz kullanılamıyor.</string>
     <string name="no_files_selected_to_clean">Temizlemek için dosya seçilmedi.</string>
+    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
     <string name="failed_to_update_trash_size">Çöp Boyutunu Güncelleme: %1$s</string>
     <string name="no_cleaning_options_selected">Lütfen devam etmek için ayarlarda temizlik tercihlerinizi seçin.</string>
     <string name="cleaning_in_progress">Temizlik devam ediyor</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -412,6 +412,7 @@
     <string name="data_not_available">Дані недоступні.</string>
     <string name="feature_not_available">Функція поки недоступна.</string>
     <string name="no_files_selected_to_clean">Жодних файлів, вибраних для очищення.</string>
+    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
     <string name="failed_to_update_trash_size">Не вдалося оновити розмір сміття: %1$s</string>
     <string name="no_cleaning_options_selected">Будь ласка, виберіть свої вподобання прибирання в налаштуваннях для продовження.</string>
     <string name="cleaning_in_progress">Триває очищення</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -412,7 +412,7 @@
     <string name="data_not_available">Дані недоступні.</string>
     <string name="feature_not_available">Функція поки недоступна.</string>
     <string name="no_files_selected_to_clean">Жодних файлів, вибраних для очищення.</string>
-    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
+    <string name="protected_android_folder">Ця папка захищена і не може бути очищена.</string>
     <string name="failed_to_update_trash_size">Не вдалося оновити розмір сміття: %1$s</string>
     <string name="no_cleaning_options_selected">Будь ласка, виберіть свої вподобання прибирання в налаштуваннях для продовження.</string>
     <string name="cleaning_in_progress">Триває очищення</string>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -396,7 +396,7 @@
     <string name="data_not_available">ڈیٹا دستیاب نہیں ہے۔</string>
     <string name="feature_not_available">فیچر ابھی دستیاب نہیں ہے۔</string>
     <string name="no_files_selected_to_clean">صاف کرنے کے لئے کوئی فائلیں منتخب نہیں کی گئیں۔</string>
-    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
+    <string name="protected_android_folder">یہ فولڈر محفوظ ہے اور صاف نہیں کیا جا سکتا۔</string>
     <string name="failed_to_update_trash_size">کوڑے دان کے سائز کو اپ ڈیٹ کرنے میں ناکام: %1$s</string>
     <string name="no_cleaning_options_selected">براہ کرم آگے بڑھنے کے لئے ترتیبات میں اپنی صفائی کی ترجیحات کا انتخاب کریں۔</string>
     <string name="cleaning_in_progress">صفائی جاری ہے</string>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -396,6 +396,7 @@
     <string name="data_not_available">ڈیٹا دستیاب نہیں ہے۔</string>
     <string name="feature_not_available">فیچر ابھی دستیاب نہیں ہے۔</string>
     <string name="no_files_selected_to_clean">صاف کرنے کے لئے کوئی فائلیں منتخب نہیں کی گئیں۔</string>
+    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
     <string name="failed_to_update_trash_size">کوڑے دان کے سائز کو اپ ڈیٹ کرنے میں ناکام: %1$s</string>
     <string name="no_cleaning_options_selected">براہ کرم آگے بڑھنے کے لئے ترتیبات میں اپنی صفائی کی ترجیحات کا انتخاب کریں۔</string>
     <string name="cleaning_in_progress">صفائی جاری ہے</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -388,7 +388,7 @@
     <string name="data_not_available">Dữ liệu không có sẵn.</string>
     <string name="feature_not_available">Tính năng hiện chưa khả dụng.</string>
     <string name="no_files_selected_to_clean">Không có tệp được chọn để làm sạch.</string>
-    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
+    <string name="protected_android_folder">Thư mục này được bảo vệ và không thể dọn dẹp.</string>
     <string name="failed_to_update_trash_size">Không cập nhật kích thước rác: %1$s</string>
     <string name="no_cleaning_options_selected">Vui lòng chọn tùy chọn làm sạch của bạn trong cài đặt để tiếp tục.</string>
     <string name="cleaning_in_progress">Đang dọn dẹp</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -388,6 +388,7 @@
     <string name="data_not_available">Dữ liệu không có sẵn.</string>
     <string name="feature_not_available">Tính năng hiện chưa khả dụng.</string>
     <string name="no_files_selected_to_clean">Không có tệp được chọn để làm sạch.</string>
+    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
     <string name="failed_to_update_trash_size">Không cập nhật kích thước rác: %1$s</string>
     <string name="no_cleaning_options_selected">Vui lòng chọn tùy chọn làm sạch của bạn trong cài đặt để tiếp tục.</string>
     <string name="cleaning_in_progress">Đang dọn dẹp</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="protected_android_folder">此文件夹受保护，无法清理。</string>
+</resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -388,7 +388,7 @@
     <string name="data_not_available">無可用資料。</string>
     <string name="feature_not_available">功能尚未可用。</string>
     <string name="no_files_selected_to_clean">未選取要清理的檔案。</string>
-    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
+    <string name="protected_android_folder">此資料夾受保護，無法清理。</string>
     <string name="failed_to_update_trash_size">更新垃圾桶大小失敗：%1$s</string>
     <string name="no_cleaning_options_selected">請在設定中選擇您的清理偏好以繼續。</string>
     <string name="cleaning_in_progress">正在清理中</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -388,6 +388,7 @@
     <string name="data_not_available">無可用資料。</string>
     <string name="feature_not_available">功能尚未可用。</string>
     <string name="no_files_selected_to_clean">未選取要清理的檔案。</string>
+    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
     <string name="failed_to_update_trash_size">更新垃圾桶大小失敗：%1$s</string>
     <string name="no_cleaning_options_selected">請在設定中選擇您的清理偏好以繼續。</string>
     <string name="cleaning_in_progress">正在清理中</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -396,6 +396,7 @@
     <string name="data_not_available">Data not available.</string>
     <string name="feature_not_available">Feature not available yet.</string>
     <string name="no_files_selected_to_clean">No files selected to clean.</string>
+    <string name="protected_android_folder">This folder is protected and cannot be cleaned.</string>
     <string name="failed_to_update_trash_size">Failed to update trash size: %1$s</string>
     <string name="no_cleaning_options_selected">Please choose your cleaning preferences in settings to proceed.</string>
     <string name="cleaning_in_progress">Cleaning in progress</string>


### PR DESCRIPTION
## Summary
- skip protected Android folders when building file lists
- ignore protected paths in selection counts and cleaning operations
- show a message when only protected folders are chosen
- localize protected-folder warning across resource files

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `apt-get install -y android-sdk` *(fails: ca-certificates-java post-installation script error)*

------
https://chatgpt.com/codex/tasks/task_e_6892f4e65900832dadc4cf31ac2ca7da