### PR TITLE
docs: expand cleaning checklist and note SAF constraints

### DIFF
--- a/docs/cleaning_feature_checklist.md
+++ b/docs/cleaning_feature_checklist.md
@@ -2,15 +2,16 @@
 
 ## Start
 - [ ] Triggered only by explicit user action
-- [ ] Persist WorkManager job ID to DataStore immediately
+- [ ] Enqueue via `FileCleaner` and persist the per-feature WorkManager ID to DataStore immediately
 - [ ] Block additional jobs while a job ID exists and notify the user
 
 ## Progress
 - [ ] Display a determinate foreground notification showing processed/total files
-- [ ] Update UI by observing WorkManager `WorkInfo`
+- [ ] Observe progress with `observeFileCleanWork` and update UI from `WorkInfo`
 
 ## Completion
 - [ ] Show a final notification summarizing success, failure, or cancellation
+- [ ] Report partial failures using `KEY_FAILED_PATHS` output
 - [ ] Clear the persisted job ID and reset UI state
 
 ## Process Death & Recovery

--- a/docs/cleaning_features.md
+++ b/docs/cleaning_features.md
@@ -1,6 +1,6 @@
 # Cleaning Features Overview
 
-Smart Cleaner provides multiple cleaning modules built on a shared cleanup architecture. Each module runs WorkManager jobs without relying on the Storage Access Framework (SAF), ensuring a streamlined file-deletion flow.
+Smart Cleaner provides multiple cleaning modules built on a shared cleanup architecture. All cleaners avoid the Storage Access Framework (SAF) and any foreground service types, running WorkManager jobs for a streamlined file-deletion flow.
 
 All cleanup jobs enqueue a `FileCleanupWorker` via the centralized [FileCleanWorkEnqueuer](../app/src/main/kotlin/com/d4rk/cleaner/core/work/FileCleanWorkEnqueuer.kt). Work request IDs for active jobs are stored in [DataStore](../app/src/main/kotlin/com/d4rk/cleaner/core/data/datastore/DataStore.kt) so each feature tracks its own progress.
 


### PR DESCRIPTION
## Summary
- document using FileCleaner with per-feature work IDs
- note progress observation and partial failure reporting
- state cleaners avoid SAF and foreground service types

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689322abf40c832d8faf01fb9fd5e25a