### PR TITLE
Show cleaning animation on WhatsApp details deletion

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/WhatsAppDetailsScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/WhatsAppDetailsScreen.kt
@@ -71,6 +71,7 @@ import com.d4rk.cleaner.app.clean.analyze.ui.components.FileCard
 import com.d4rk.cleaner.app.clean.scanner.ui.components.FileListItem
 import com.d4rk.cleaner.app.clean.scanner.ui.components.FilePreviewCard
 import com.d4rk.cleaner.app.clean.scanner.utils.helpers.FilePreviewHelper
+import com.d4rk.cleaner.app.clean.analyze.ui.components.CleaningAnimationScreen
 import com.d4rk.cleaner.app.clean.whatsapp.details.domain.actions.WhatsAppDetailsEvent
 import com.d4rk.cleaner.app.clean.whatsapp.details.domain.model.UiWhatsAppDetailsModel
 import com.d4rk.cleaner.app.clean.whatsapp.details.ui.components.CustomTabLayout
@@ -158,7 +159,13 @@ fun DetailsScreen(
     ) { paddingValues ->
         ScreenStateHandler(
             screenState = state,
-            onLoading = { LoadingScreen() },
+            onLoading = {
+                if (state.data?.cleaningState == CleaningState.Cleaning) {
+                    CleaningAnimationScreen()
+                } else {
+                    LoadingScreen()
+                }
+            },
             onEmpty = {
                 NoDataScreen(
                     icon = Icons.Outlined.FolderOff,


### PR DESCRIPTION
## Summary
- animate deletion in WhatsApp details screen using CleaningAnimationScreen for consistency with analyze screen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689326bbfa38832d8e69048ada77c97e