### PR TITLE
Add feature module template and improve clipboard cleaner

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/clipboard/ui/ClipboardCleanerActivity.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/clipboard/ui/ClipboardCleanerActivity.kt
@@ -11,8 +11,12 @@ class ClipboardCleanerActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val manager = getSystemService(CLIPBOARD_SERVICE) as? ClipboardManager
-        manager?.clearClipboardCompat()
-        Toast.makeText(this, R.string.clipboard_cleaned, Toast.LENGTH_SHORT).show()
+        if (manager != null) {
+            manager.clearClipboardCompat()
+            Toast.makeText(this, R.string.clipboard_cleaned, Toast.LENGTH_SHORT).show()
+        } else {
+            Toast.makeText(this, R.string.clipboard_service_unavailable, Toast.LENGTH_SHORT).show()
+        }
         finishAndRemoveTask()
     }
 }

--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -166,6 +166,7 @@
     <string name="clipboard_current_format">الحافظة الحالية: %1$s</string>
     <string name="clean_clipboard">مسح الحافظة</string>
     <string name="clipboard_cleaned">تم تنظيف الحافظة</string>
+    <string name="clipboard_service_unavailable">خدمة الحافظة غير متوفرة</string>
     <string name="link_cleaner">منظف الروابط</string>
     <string name="link_cleaned">تم تنظيف الرابط</string>
     <string name="link_cleaner_card_title">منظف الروابط</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -154,6 +154,7 @@
     <string name="clipboard_current_format">Текущ клипборд: %1$s</string>
     <string name="clean_clipboard">Изчисти клипборда</string>
     <string name="clipboard_cleaned">Клипбордът е почистен</string>
+    <string name="clipboard_service_unavailable">Услугата за клипборд е недостъпна</string>
     <string name="link_cleaner">Почистващ връзки</string>
     <string name="link_cleaned">Връзката е почистена</string>
     <string name="link_cleaner_card_title">Почистващ връзки</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -154,6 +154,7 @@
     <string name="clipboard_current_format">বর্তমান ক্লিপবোর্ড: %1$s</string>
     <string name="clean_clipboard">ক্লিপবোর্ড পরিষ্কার করুন</string>
     <string name="clipboard_cleaned">ক্লিপবোর্ড পরিষ্কার করা হয়েছে</string>
+    <string name="clipboard_service_unavailable">ক্লিপবোর্ড পরিষেবা অনুপলব্ধ</string>
     <string name="link_cleaner">লিঙ্ক ক্লিনার</string>
     <string name="link_cleaned">লিঙ্ক পরিষ্কার হয়েছে</string>
     <string name="link_cleaner_card_title">লিঙ্ক ক্লিনার</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -154,6 +154,7 @@
     <string name="clipboard_current_format">Aktuelle Zwischenablage: %1$s</string>
     <string name="clean_clipboard">Zwischenablage leeren</string>
     <string name="clipboard_cleaned">Die Zwischenablage wurde gereinigt</string>
+    <string name="clipboard_service_unavailable">Zwischenablage-Dienst nicht verfügbar</string>
     <string name="link_cleaner">Link-Reiniger</string>
     <string name="link_cleaned">Link bereinigt</string>
     <string name="link_cleaner_card_title">Link-Reiniger</string>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -157,6 +157,7 @@
     <string name="clipboard_current_format">Portapapeles actual: %1$s</string>
     <string name="clean_clipboard">Borrar portapapeles</string>
     <string name="clipboard_cleaned">El portapapeles ha sido limpiado</string>
+    <string name="clipboard_service_unavailable">Servicio de portapapeles no disponible</string>
     <string name="link_cleaner">Limpiador de enlaces</string>
     <string name="link_cleaned">Enlace limpiado</string>
     <string name="link_cleaner_card_title">Limpiador de enlaces</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -157,6 +157,7 @@
     <string name="clipboard_current_format">Portapapeles actual: %1$s</string>
     <string name="clean_clipboard">Borrar portapapeles</string>
     <string name="clipboard_cleaned">El portapapeles ha sido limpiado</string>
+    <string name="clipboard_service_unavailable">Servicio de portapapeles no disponible</string>
     <string name="link_cleaner">Limpiador de enlaces</string>
     <string name="link_cleaned">Enlace limpiado</string>
     <string name="link_cleaner_card_title">Limpiador de enlaces</string>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -154,6 +154,7 @@
     <string name="clipboard_current_format">Kasalukuyang clipboard: %1$s</string>
     <string name="clean_clipboard">I-clear ang Clipboard</string>
     <string name="clipboard_cleaned">Ang clipboard ay nalinis</string>
+    <string name="clipboard_service_unavailable">Hindi magagamit ang serbisyo ng clipboard</string>
     <string name="link_cleaner">Tagalinis ng Link</string>
     <string name="link_cleaned">Nalinis ang link</string>
     <string name="link_cleaner_card_title">Tagalinis ng Link</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -157,6 +157,7 @@
     <string name="clipboard_current_format">Presse-papiers actuel : %1$s</string>
     <string name="clean_clipboard">Effacer le presse-papiers</string>
     <string name="clipboard_cleaned">Le presse-papiers a été nettoyé</string>
+    <string name="clipboard_service_unavailable">Service de presse-papiers indisponible</string>
     <string name="link_cleaner">Nettoyeur de liens</string>
     <string name="link_cleaned">Lien nettoyé</string>
     <string name="link_cleaner_card_title">Nettoyeur de liens</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -154,6 +154,7 @@
     <string name="clipboard_current_format">वर्तमान क्लिपबोर्ड: %1$s</string>
     <string name="clean_clipboard">क्लिपबोर्ड साफ़ करें</string>
     <string name="clipboard_cleaned">क्लिपबोर्ड को साफ किया गया है</string>
+    <string name="clipboard_service_unavailable">क्लिपबोर्ड सेवा अनुपलब्ध</string>
     <string name="link_cleaner">लिंक क्लीनर</string>
     <string name="link_cleaned">लिंक साफ़ किया गया</string>
     <string name="link_cleaner_card_title">लिंक क्लीनर</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -154,6 +154,7 @@
     <string name="clipboard_current_format">Aktuális vágólap: %1$s</string>
     <string name="clean_clipboard">Vágólap törlése</string>
     <string name="clipboard_cleaned">A vágólapot megtisztították</string>
+    <string name="clipboard_service_unavailable">A vágólap szolgáltatása nem érhető el</string>
     <string name="link_cleaner">Linktisztító</string>
     <string name="link_cleaned">A linket megtisztították</string>
     <string name="link_cleaner_card_title">Linktisztító</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -151,6 +151,7 @@
     <string name="clipboard_current_format">Clipboard saat ini: %1$s</string>
     <string name="clean_clipboard">Bersihkan Clipboard</string>
     <string name="clipboard_cleaned">Clipboard telah dibersihkan</string>
+    <string name="clipboard_service_unavailable">Layanan Clipboard tidak tersedia</string>
     <string name="link_cleaner">Pembersih Tautan</string>
     <string name="link_cleaned">Tautan telah dibersihkan</string>
     <string name="link_cleaner_card_title">Pembersih Tautan</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -157,6 +157,7 @@
     <string name="clipboard_current_format">Appunti correnti: %1$s</string>
     <string name="clean_clipboard">Cancella appunti</string>
     <string name="clipboard_cleaned">Gli appunti sono stati puliti</string>
+    <string name="clipboard_service_unavailable">Servizio degli appunti non disponibile</string>
     <string name="link_cleaner">Pulitore link</string>
     <string name="link_cleaned">Link pulito</string>
     <string name="link_cleaner_card_title">Pulitore link</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -151,6 +151,7 @@
     <string name="clipboard_current_format">現在のクリップボード: %1$s</string>
     <string name="clean_clipboard">クリップボードを消去</string>
     <string name="clipboard_cleaned">クリップボードが掃除されました</string>
+    <string name="clipboard_service_unavailable">クリップボードサービスは利用できません</string>
     <string name="link_cleaner">リンククリーナー</string>
     <string name="link_cleaned">リンクをクリーンしました</string>
     <string name="link_cleaner_card_title">リンククリーナー</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -151,6 +151,7 @@
     <string name="clipboard_current_format">현재 클립보드: %1$s</string>
     <string name="clean_clipboard">클립보드 지우기</string>
     <string name="clipboard_cleaned">클립 보드가 청소되었습니다</string>
+    <string name="clipboard_service_unavailable">클립보드 서비스를 사용할 수 없습니다</string>
     <string name="link_cleaner">링크 클리너</string>
     <string name="link_cleaned">링크가 정리되었습니다</string>
     <string name="link_cleaner_card_title">링크 클리너</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -160,6 +160,7 @@
     <string name="clipboard_current_format">Aktualny schowek: %1$s</string>
     <string name="clean_clipboard">Wyczyść schowek</string>
     <string name="clipboard_cleaned">Schowek został wyczyszczony</string>
+    <string name="clipboard_service_unavailable">Usługa schowka niedostępna</string>
     <string name="link_cleaner">Czyszczenie linków</string>
     <string name="link_cleaned">Link wyczyszczony</string>
     <string name="link_cleaner_card_title">Czyszczenie linków</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -157,6 +157,7 @@
     <string name="clipboard_current_format">Área de transferência atual: %1$s</string>
     <string name="clean_clipboard">Limpar área de transferência</string>
     <string name="clipboard_cleaned">A área de transferência foi limpa</string>
+    <string name="clipboard_service_unavailable">Serviço de área de transferência indisponível</string>
     <string name="link_cleaner">Limpador de links</string>
     <string name="link_cleaned">Link limpo</string>
     <string name="link_cleaner_card_title">Limpador de links</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -157,6 +157,7 @@
     <string name="clipboard_current_format">Clipboard curent: %1$s</string>
     <string name="clean_clipboard">Curăță clipboard-ul</string>
     <string name="clipboard_cleaned">Clipboard a fost curățat</string>
+    <string name="clipboard_service_unavailable">Serviciul de clipboard indisponibil</string>
     <string name="link_cleaner">Curățare linkuri</string>
     <string name="link_cleaned">Link curățat</string>
     <string name="link_cleaner_card_title">Curățare linkuri</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -160,6 +160,7 @@
     <string name="clipboard_current_format">Текущий буфер: %1$s</string>
     <string name="clean_clipboard">Очистить буфер обмена</string>
     <string name="clipboard_cleaned">Буфер обмена очищен</string>
+    <string name="clipboard_service_unavailable">Служба буфера обмена недоступна</string>
     <string name="link_cleaner">Очистка ссылок</string>
     <string name="link_cleaned">Ссылка очищена</string>
     <string name="link_cleaner_card_title">Очистка ссылок</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -154,6 +154,7 @@
     <string name="clipboard_current_format">Aktuellt urklipp: %1$s</string>
     <string name="clean_clipboard">Rensa urklipp</string>
     <string name="clipboard_cleaned">Urklipp har rengjorts</string>
+    <string name="clipboard_service_unavailable">Urklippstjänsten är inte tillgänglig</string>
     <string name="link_cleaner">Länkrensare</string>
     <string name="link_cleaned">Länken rensad</string>
     <string name="link_cleaner_card_title">Länkrensare</string>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -151,6 +151,7 @@
     <string name="clipboard_current_format">คลิปบอร์ดปัจจุบัน: %1$s</string>
     <string name="clean_clipboard">ล้างคลิปบอร์ด</string>
     <string name="clipboard_cleaned">คลิปบอร์ดได้รับการทำความสะอาด</string>
+    <string name="clipboard_service_unavailable">บริการคลิปบอร์ดไม่พร้อมใช้งาน</string>
     <string name="link_cleaner">ตัวล้างลิงก์</string>
     <string name="link_cleaned">ลิงก์ถูกล้างแล้ว</string>
     <string name="link_cleaner_card_title">ตัวล้างลิงก์</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -154,6 +154,7 @@
     <string name="clipboard_current_format">Geçerli pano: %1$s</string>
     <string name="clean_clipboard">Panoyu Temizle</string>
     <string name="clipboard_cleaned">Pano temizlendi</string>
+    <string name="clipboard_service_unavailable">Pano hizmeti kullanılamıyor</string>
     <string name="link_cleaner">Bağlantı Temizleyici</string>
     <string name="link_cleaned">Bağlantı temizlendi</string>
     <string name="link_cleaner_card_title">Bağlantı Temizleyici</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -160,6 +160,7 @@
     <string name="clipboard_current_format">Поточний буфер: %1$s</string>
     <string name="clean_clipboard">Очистити буфер обміну</string>
     <string name="clipboard_cleaned">Буфер обміну був очищений</string>
+    <string name="clipboard_service_unavailable">Служба буфера обміну недоступна</string>
     <string name="link_cleaner">Очищувач посилань</string>
     <string name="link_cleaned">Посилання очищено</string>
     <string name="link_cleaner_card_title">Очищувач посилань</string>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -154,6 +154,7 @@
     <string name="clipboard_current_format">موجودہ کلپ بورڈ: %1$s</string>
     <string name="clean_clipboard">کلپ بورڈ صاف کریں</string>
     <string name="clipboard_cleaned">کلپ بورڈ صاف کیا گیا ہے</string>
+    <string name="clipboard_service_unavailable">کلپ بورڈ سروس دستیاب نہیں ہے</string>
     <string name="link_cleaner">لنک کلینر</string>
     <string name="link_cleaned">لنک صاف ہوگیا</string>
     <string name="link_cleaner_card_title">لنک کلینر</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -151,6 +151,7 @@
     <string name="clipboard_current_format">Bảng tạm hiện tại: %1$s</string>
     <string name="clean_clipboard">Xóa bảng tạm</string>
     <string name="clipboard_cleaned">Clipboard đã được làm sạch</string>
+    <string name="clipboard_service_unavailable">Dịch vụ clipboard không khả dụng</string>
     <string name="link_cleaner">Trình làm sạch liên kết</string>
     <string name="link_cleaned">Liên kết đã được làm sạch</string>
     <string name="link_cleaner_card_title">Trình làm sạch liên kết</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -151,6 +151,7 @@
     <string name="clipboard_current_format">目前剪貼簿：%1$s</string>
     <string name="clean_clipboard">清除剪貼簿</string>
     <string name="clipboard_cleaned">剪貼板已清潔</string>
+    <string name="clipboard_service_unavailable">剪貼板服務不可用</string>
     <string name="link_cleaner">連結清理</string>
     <string name="link_cleaned">連結已清理</string>
     <string name="link_cleaner_card_title">連結清理</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -154,6 +154,7 @@
     <string name="clipboard_current_format">Current clipboard: %1$s</string>
     <string name="clean_clipboard">Clear Clipboard</string>
     <string name="clipboard_cleaned">Clipboard cleaned</string>
+    <string name="clipboard_service_unavailable">Clipboard service unavailable</string>
     <string name="link_cleaner">Link Cleaner</string>
     <string name="link_cleaned">Link cleaned</string>
     <string name="link_cleaner_card_title">Link Cleaner</string>

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,3 +16,4 @@ This directory contains technical and product documentation for the Smart Cleane
 - [Cleaning Feature Checklist](cleaning_feature_checklist.md)
 - [Testing Strategy](testing_strategy.md)
 - [Development Guidelines](development_guidelines.md)
+- [Feature Module Template](feature_module_template.md)

--- a/docs/clipboard_cleaner.md
+++ b/docs/clipboard_cleaner.md
@@ -1,7 +1,7 @@
 # Clipboard Cleaner
 
 ## Triggers
-- **Manual:** user launches `ClipboardCleanerActivity`, which wipes the clipboard and shows a toast before finishing【F:app/src/main/kotlin/com/d4rk/cleaner/app/clean/clipboard/ui/ClipboardCleanerActivity.kt†L10-L16】.
+- **Manual:** user launches `ClipboardCleanerActivity`, which wipes the clipboard and shows a toast before finishing【F:app/src/main/kotlin/com/d4rk/cleaner/app/clean/clipboard/ui/ClipboardCleanerActivity.kt†L10-L20】.
 - **Automatic:** when notification listener permission is granted, `ClipboardNotificationListenerService` clears the clipboard whenever the screen turns off【F:app/src/main/kotlin/com/d4rk/cleaner/app/clean/clipboard/services/ClipboardNotificationListenerService.kt†L15-L36】.
 
 ## UI States
@@ -11,11 +11,8 @@
 - Clipboard contents live only in memory; nothing is persisted.
 
 ## Error Handling
-- If the clipboard service is unavailable, the activity silently finishes. No retry logic is required.
+- If the clipboard service is unavailable, an error toast notifies the user before closing.
 
 ## System Events
 - Screen-off events trigger automatic cleaning when the service is active.
 - Process death has no effect beyond stopping automatic clearing until the service is restarted.
-
-## TODO
-- Consider surfacing an error toast when the clipboard service is missing.

--- a/docs/development_guidelines.md
+++ b/docs/development_guidelines.md
@@ -20,5 +20,5 @@
 - Extend `PreviewType` and update `getPreviewType` in `FilePreviewHelper` to support new file formats.
 - Respect memory limits: previews should decode on `Dispatchers.IO` and rely on the shared `LruCache`.
 
-## TODO
-- Provide a template or script for creating new feature modules.
+## Feature Module Template
+- Refer to the [Feature Module Template](feature_module_template.md) for scaffolding new cleanup features.

--- a/docs/feature_module_template.md
+++ b/docs/feature_module_template.md
@@ -1,0 +1,36 @@
+# Feature Module Template
+
+This template helps scaffold a new cleaning feature. Replace `example` with your feature name.
+
+## Directory Structure
+
+```
+app/
+ └── clean/
+     └── example/
+         ├── domain/
+         │   └── ExampleUseCase.kt
+         ├── handler/
+         │   └── ExampleHandler.kt
+         └── ui/
+             ├── ExampleScreen.kt
+             └── ExampleViewModel.kt
+```
+
+## Sample Activity
+
+```kotlin
+class ExampleCleanerActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            ExampleScreen(viewModel = hiltViewModel())
+        }
+    }
+}
+```
+
+## Next Steps
+- Add strings in `strings.xml` and provide translations.
+- Write a doc page for the feature and link it from `docs/README.md`.
+- Register any WorkManager jobs or notifications as needed.


### PR DESCRIPTION
## Summary
- add feature module template doc and link it from developer docs
- show an error toast if the clipboard service is unavailable
- document clipboard cleaner behaviour and update dev guidelines

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893ba6e4f28832d9fcf347ac6d4e908