### PR TITLE
Fix cleaning animation delay and snackbar behavior

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/CleanOperationHandler.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/CleanOperationHandler.kt
@@ -189,7 +189,11 @@ class CleanOperationHandler(
                 getWorkId = { dataStore.scannerCleanWorkId.first() },
                 saveWorkId = { dataStore.saveScannerCleanWorkId(it) },
                 clearWorkId = { dataStore.clearScannerCleanWorkId() },
-                showSnackbar = { postSnackbar(it.message, it.isError) },
+                showSnackbar = { snackbar ->
+                    if (snackbar.isError) {
+                        postSnackbar(snackbar.message, true)
+                    }
+                },
                 onEnqueued = { id ->
                     uiState.update { state ->
                         val currentData = state.data ?: UiScannerModel()
@@ -234,7 +238,11 @@ class CleanOperationHandler(
                 getWorkId = { dataStore.scannerCleanWorkId.first() },
                 saveWorkId = { dataStore.saveScannerCleanWorkId(it) },
                 clearWorkId = { dataStore.clearScannerCleanWorkId() },
-                showSnackbar = { postSnackbar(it.message, it.isError) },
+                showSnackbar = { snackbar ->
+                    if (snackbar.isError) {
+                        postSnackbar(snackbar.message, true)
+                    }
+                },
                 onEnqueued = { id ->
                     uiState.update { state: UiStateScreen<UiScannerModel> ->
                         val currentData: UiScannerModel = state.data ?: UiScannerModel()

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
@@ -550,6 +550,19 @@ class ScannerViewModel(
                 }
             },
             onSuccess = { info ->
+                _uiState.update { state ->
+                    val current = state.data ?: UiScannerModel()
+                    state.copy(
+                        data = current.copy(
+                            analyzeState = current.analyzeState.copy(
+                                state = CleaningState.Result
+                            )
+                        )
+                    )
+                }
+
+                _cleaningApks.value = false
+
                 val failedPaths =
                     info.outputData.getStringArray(FileCleanupWorker.KEY_FAILED_PATHS)
                 val failedCount = failedPaths?.size ?: 0
@@ -575,18 +588,7 @@ class ScannerViewModel(
                     pendingEmptyFoldersCleanup = false
                 }
                 dataStore.saveLastScanTimestamp(System.currentTimeMillis())
-                _cleaningApks.value = false
 
-                _uiState.update { state ->
-                    val current = state.data ?: UiScannerModel()
-                    state.copy(
-                        data = current.copy(
-                            analyzeState = current.analyzeState.copy(
-                                state = CleaningState.Result
-                            )
-                        )
-                    )
-                }
                 onEvent(ScannerEvent.RefreshData)
                 onCloseAnalyzeComposable()
             },
@@ -750,6 +752,7 @@ class ScannerViewModel(
 
     private fun toggleAnalyzeScreen(visible: Boolean) {
         if (visible) {
+            screenState.dismissSnackbar()
             launch(dispatchers.io) {
                 val anyEnabled = listOf(
                     dataStore.genericFilter.first(),


### PR DESCRIPTION
## Summary
- hide "Cleaning in progress" snackbar on analyze screen by ignoring non-error messages and dismissing any active snackbar when the screen opens
- update cleaning state immediately on success to prevent lingering animation

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894d42152ec832db7706f1b00e4ef3b