### PR TITLE
feat: add global select all warning dialog

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/AnalyzeScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/AnalyzeScreen.kt
@@ -26,6 +26,7 @@ import com.d4rk.cleaner.R
 import com.d4rk.cleaner.app.clean.analyze.ui.components.CleaningAnimationScreen
 import com.d4rk.cleaner.app.clean.analyze.ui.components.StatusRowSelectAll
 import com.d4rk.cleaner.app.clean.analyze.ui.components.dialogs.DeleteOrTrashConfirmation
+import com.d4rk.cleaner.app.clean.analyze.ui.components.dialogs.GlobalSelectAllWarningDialog
 import com.d4rk.cleaner.app.clean.analyze.ui.components.tabs.TabsContent
 import com.d4rk.cleaner.app.clean.nofilesfound.ui.NoFilesFoundScreen
 import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.CleaningState
@@ -106,7 +107,7 @@ fun AnalyzeScreen(
             StatusRowSelectAll(
                 data = data,
                 view = view,
-                onClickSelectAll = { viewModel.toggleSelectAllFiles() },
+                onClickSelectAll = { viewModel.onEvent(ScannerEvent.OnGlobalSelectAllClick) },
             )
         }
 
@@ -129,6 +130,15 @@ fun AnalyzeScreen(
 
         if (data.analyzeState.isDeleteForeverConfirmationDialogVisible || data.analyzeState.isMoveToTrashConfirmationDialogVisible) {
             DeleteOrTrashConfirmation(data = data, viewModel = viewModel)
+        }
+
+        if (data.analyzeState.isGlobalSelectAllWarningDialogVisible) {
+            GlobalSelectAllWarningDialog(
+                onConfirm = { dontShowAgain ->
+                    viewModel.onEvent(ScannerEvent.ConfirmGlobalSelectAll(dontShowAgain))
+                },
+                onDismiss = { viewModel.onEvent(ScannerEvent.DismissGlobalSelectAllWarning) }
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/components/dialogs/GlobalSelectAllWarningDialog.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/components/dialogs/GlobalSelectAllWarningDialog.kt
@@ -1,0 +1,41 @@
+package com.d4rk.cleaner.app.clean.analyze.ui.components.dialogs
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.d4rk.android.libs.apptoolkit.core.ui.components.dialogs.BasicAlertDialog
+import com.d4rk.cleaner.R
+
+@Composable
+fun GlobalSelectAllWarningDialog(
+    onConfirm: (dontShowAgain: Boolean) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var dontShowAgain by remember { mutableStateOf(false) }
+
+    BasicAlertDialog(
+        title = stringResource(id = R.string.select_all_files_title),
+        content = {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                Text(text = stringResource(id = R.string.select_all_files_message))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Checkbox(checked = dontShowAgain, onCheckedChange = { dontShowAgain = it })
+                    Text(text = stringResource(id = R.string.dont_show_again))
+                }
+            }
+        },
+        confirmButtonText = stringResource(id = R.string.select_all),
+        onConfirm = { onConfirm(dontShowAgain) },
+        onDismiss = onDismiss
+    )
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/components/dialogs/GlobalSelectAllWarningDialog.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/components/dialogs/GlobalSelectAllWarningDialog.kt
@@ -30,7 +30,7 @@ fun GlobalSelectAllWarningDialog(
                 Text(text = stringResource(id = R.string.select_all_files_message))
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Checkbox(checked = dontShowAgain, onCheckedChange = { dontShowAgain = it })
-                    Text(text = stringResource(id = R.string.dont_show_again))
+                    Text(text = stringResource(id = R.string.dont_show_warning_again))
                 }
             }
         },

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/domain/actions/ScannerEvent.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/domain/actions/ScannerEvent.kt
@@ -13,6 +13,9 @@ sealed class ScannerEvent : UiEvent {
     data class ToggleAnalyzeScreen(val visible: Boolean) : ScannerEvent()
     data class OnFileSelectionChange(val file: File, val isChecked: Boolean) : ScannerEvent()
     object ToggleSelectAllFiles : ScannerEvent()
+    object OnGlobalSelectAllClick : ScannerEvent()
+    data class ConfirmGlobalSelectAll(val dontShowAgain: Boolean) : ScannerEvent()
+    object DismissGlobalSelectAllWarning : ScannerEvent()
     data class ToggleSelectFilesForCategory(val category: String) : ScannerEvent()
     data class ToggleSelectFilesForDate(val files: List<File>, val isChecked: Boolean) :
         ScannerEvent()

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/domain/data/model/ui/UiScannerModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/domain/data/model/ui/UiScannerModel.kt
@@ -36,6 +36,7 @@ data class UiAnalyzeModel(
     var fileTypesData: FileTypesData = FileTypesData(),
     var isDeleteForeverConfirmationDialogVisible: Boolean = false,
     var isMoveToTrashConfirmationDialogVisible: Boolean = false,
+    var isGlobalSelectAllWarningDialogVisible: Boolean = false,
 )
 
 data class FileTypesData(

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
@@ -182,6 +182,9 @@ class ScannerViewModel(
             )
 
             is ScannerEvent.ToggleSelectAllFiles -> toggleSelectAllFiles()
+            is ScannerEvent.OnGlobalSelectAllClick -> onGlobalSelectAllClick()
+            is ScannerEvent.ConfirmGlobalSelectAll -> confirmGlobalSelectAll(event.dontShowAgain)
+            is ScannerEvent.DismissGlobalSelectAllWarning -> setGlobalSelectAllWarningDialogVisibility(false)
             is ScannerEvent.ToggleSelectFilesForCategory -> toggleSelectFilesForCategory(category = event.category)
             is ScannerEvent.ToggleSelectFilesForDate -> toggleSelectFilesForDate(
                 event.files,
@@ -442,6 +445,40 @@ class ScannerViewModel(
                     )
                 )
             }
+        }
+    }
+
+    private fun setGlobalSelectAllWarningDialogVisibility(isVisible: Boolean) {
+        _uiState.update { state: UiStateScreen<UiScannerModel> ->
+            val currentData: UiScannerModel = state.data ?: UiScannerModel()
+            state.copy(
+                data = currentData.copy(
+                    analyzeState = currentData.analyzeState.copy(
+                        isGlobalSelectAllWarningDialogVisible = isVisible
+                    )
+                )
+            )
+        }
+    }
+
+    private fun onGlobalSelectAllClick() {
+        launch(context = dispatchers.io) {
+            val showDialog = dataStore.showGlobalSelectAllWarning.first()
+            if (showDialog) {
+                setGlobalSelectAllWarningDialogVisibility(true)
+            } else {
+                toggleSelectAllFiles()
+            }
+        }
+    }
+
+    private fun confirmGlobalSelectAll(dontShowAgain: Boolean) {
+        launch(context = dispatchers.io) {
+            if (dontShowAgain) {
+                dataStore.saveShowGlobalSelectAllWarning(false)
+            }
+            toggleSelectAllFiles()
+            setGlobalSelectAllWarningDialogVisibility(false)
         }
     }
 

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/data/datastore/DataStore.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/data/datastore/DataStore.kt
@@ -429,6 +429,18 @@ class DataStore(val context: Context) : CommonDataStore(context = context) {
         }
     }
 
+    private val showGlobalSelectAllWarningKey =
+        booleanPreferencesKey(AppDataStoreConstants.DATA_STORE_SHOW_GLOBAL_SELECT_ALL_WARNING)
+    val showGlobalSelectAllWarning: Flow<Boolean> = dataStore.data.map { prefs ->
+        prefs[showGlobalSelectAllWarningKey] ?: true
+    }
+
+    suspend fun saveShowGlobalSelectAllWarning(show: Boolean) {
+        dataStore.edit { prefs ->
+            prefs[showGlobalSelectAllWarningKey] = show
+        }
+    }
+
     private val streakCountKey =
         intPreferencesKey(name = AppDataStoreConstants.DATA_STORE_STREAK_COUNT)
     val streakCount: Flow<Int> = dataStore.data.map { prefs ->

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/constants/datastore/AppDataStoreConstants.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/constants/datastore/AppDataStoreConstants.kt
@@ -31,6 +31,7 @@ object AppDataStoreConstants : DataStoreNamesConstants() {
     const val DATA_STORE_DELETE_FONT_FILES = "delete_font_files"
     const val DATA_STORE_OTHER_EXTENSIONS = "other_extensions"
     const val DATA_STORE_WHATSAPP_GRID_VIEW = "whatsapp_grid_view"
+    const val DATA_STORE_SHOW_GLOBAL_SELECT_ALL_WARNING = "show_global_select_all_warning"
     const val DATA_STORE_STREAK_COUNT = "streak_count"
     const val DATA_STORE_STREAK_RECORD = "streak_record"
     const val DATA_STORE_LAST_CLEAN_DAY = "last_clean_day"

--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -228,6 +228,9 @@
     </plurals>
     <string name="status_no_files_selected">الحالة: مفيش ملفات متحددة</string>
     <string name="select_all">تحديد الكل</string>
+    <string name="select_all_files_title">تحديد كل الملفات؟</string>
+    <string name="select_all_files_message">أنت على وشك تحديد كل الملفات المعروضة على هذه الشاشة.\\n\\nهل أنت متأكد أنك تريد المتابعة؟</string>
+    <string name="dont_show_warning_again">لا تظهر هذا التحذير مرة أخرى</string>
     <string name="delete_confirmation_title">حذف المحدد</string>
     <plurals name="delete_confirmation_message">
         <item quantity="zero">هل تريد حذف %1$d ملف؟</item>

--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -229,7 +229,7 @@
     <string name="status_no_files_selected">الحالة: مفيش ملفات متحددة</string>
     <string name="select_all">تحديد الكل</string>
     <string name="select_all_files_title">تحديد كل الملفات؟</string>
-    <string name="select_all_files_message">أنت على وشك تحديد كل الملفات المعروضة على هذه الشاشة.&#10;&#10;هل أنت متأكد أنك تريد المتابعة؟</string>
+    <string name="select_all_files_message">أنت على وشك تحديد كل الملفات المعروضة على هذه الشاشة.\n\nهل أنت متأكد أنك تريد المتابعة؟</string>
     <string name="dont_show_warning_again">لا تظهر هذا التحذير مرة أخرى</string>
     <string name="delete_confirmation_title">حذف المحدد</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -229,7 +229,7 @@
     <string name="status_no_files_selected">الحالة: مفيش ملفات متحددة</string>
     <string name="select_all">تحديد الكل</string>
     <string name="select_all_files_title">تحديد كل الملفات؟</string>
-    <string name="select_all_files_message">أنت على وشك تحديد كل الملفات المعروضة على هذه الشاشة.\\n\\nهل أنت متأكد أنك تريد المتابعة؟</string>
+    <string name="select_all_files_message">أنت على وشك تحديد كل الملفات المعروضة على هذه الشاشة.&#10;&#10;هل أنت متأكد أنك تريد المتابعة؟</string>
     <string name="dont_show_warning_again">لا تظهر هذا التحذير مرة أخرى</string>
     <string name="delete_confirmation_title">حذف المحدد</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -209,7 +209,7 @@
     <string name="status_no_files_selected">Състояние: Няма избрани файлове</string>
     <string name="select_all">Избери всички</string>
     <string name="select_all_files_title">Избор на всички файлове?</string>
-    <string name="select_all_files_message">На път сте да изберете всички файлове, показани на този екран.&#10;&#10;Сигурни ли сте, че искате да продължите?</string>
+    <string name="select_all_files_message">На път сте да изберете всички файлове, показани на този екран.\n\nСигурни ли сте, че искате да продължите?</string>
     <string name="dont_show_warning_again">Не показвай повече това предупреждение</string>
     <string name="delete_confirmation_title">Изтриване на избраното</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -209,7 +209,7 @@
     <string name="status_no_files_selected">Състояние: Няма избрани файлове</string>
     <string name="select_all">Избери всички</string>
     <string name="select_all_files_title">Избор на всички файлове?</string>
-    <string name="select_all_files_message">На път сте да изберете всички файлове, показани на този екран.\\n\\nСигурни ли сте, че искате да продължите?</string>
+    <string name="select_all_files_message">На път сте да изберете всички файлове, показани на този екран.&#10;&#10;Сигурни ли сте, че искате да продължите?</string>
     <string name="dont_show_warning_again">Не показвай повече това предупреждение</string>
     <string name="delete_confirmation_title">Изтриване на избраното</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -208,6 +208,9 @@
     </plurals>
     <string name="status_no_files_selected">Състояние: Няма избрани файлове</string>
     <string name="select_all">Избери всички</string>
+    <string name="select_all_files_title">Избор на всички файлове?</string>
+    <string name="select_all_files_message">На път сте да изберете всички файлове, показани на този екран.\\n\\nСигурни ли сте, че искате да продължите?</string>
+    <string name="dont_show_warning_again">Не показвай повече това предупреждение</string>
     <string name="delete_confirmation_title">Изтриване на избраното</string>
     <plurals name="delete_confirmation_message">
         <item quantity="one">Да изтрия %1$d елемент?</item>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -208,6 +208,9 @@
     </plurals>
     <string name="status_no_files_selected">স্থিতি: কোনও ফাইল নির্বাচিত নেই</string>
     <string name="select_all">সব নির্বাচন করুন</string>
+    <string name="select_all_files_title">সব ফাইল নির্বাচন করবেন?</string>
+    <string name="select_all_files_message">আপনি এই স্ক্রিনে দেখানো প্রতিটি ফাইল নির্বাচন করতে যাচ্ছেন।\\n\\nআপনি কি চালিয়ে যেতে নিশ্চিত?</string>
+    <string name="dont_show_warning_again">এই সতর্কতাটি আর দেখাবেন না</string>
     <string name="delete_confirmation_title">নির্বাচিত মুছে ফেলুন</string>
     <plurals name="delete_confirmation_message">
         <item quantity="one">কী %1$d আইটেম মুছে ফেলতে চান?</item>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -209,7 +209,7 @@
     <string name="status_no_files_selected">স্থিতি: কোনও ফাইল নির্বাচিত নেই</string>
     <string name="select_all">সব নির্বাচন করুন</string>
     <string name="select_all_files_title">সব ফাইল নির্বাচন করবেন?</string>
-    <string name="select_all_files_message">আপনি এই স্ক্রিনে দেখানো প্রতিটি ফাইল নির্বাচন করতে যাচ্ছেন।\\n\\nআপনি কি চালিয়ে যেতে নিশ্চিত?</string>
+    <string name="select_all_files_message">আপনি এই স্ক্রিনে দেখানো প্রতিটি ফাইল নির্বাচন করতে যাচ্ছেন।&#10;&#10;আপনি কি চালিয়ে যেতে নিশ্চিত?</string>
     <string name="dont_show_warning_again">এই সতর্কতাটি আর দেখাবেন না</string>
     <string name="delete_confirmation_title">নির্বাচিত মুছে ফেলুন</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -209,7 +209,7 @@
     <string name="status_no_files_selected">স্থিতি: কোনও ফাইল নির্বাচিত নেই</string>
     <string name="select_all">সব নির্বাচন করুন</string>
     <string name="select_all_files_title">সব ফাইল নির্বাচন করবেন?</string>
-    <string name="select_all_files_message">আপনি এই স্ক্রিনে দেখানো প্রতিটি ফাইল নির্বাচন করতে যাচ্ছেন।&#10;&#10;আপনি কি চালিয়ে যেতে নিশ্চিত?</string>
+    <string name="select_all_files_message">আপনি এই স্ক্রিনে দেখানো প্রতিটি ফাইল নির্বাচন করতে যাচ্ছেন।\n\nআপনি কি চালিয়ে যেতে নিশ্চিত?</string>
     <string name="dont_show_warning_again">এই সতর্কতাটি আর দেখাবেন না</string>
     <string name="delete_confirmation_title">নির্বাচিত মুছে ফেলুন</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -209,7 +209,7 @@
     <string name="status_no_files_selected">Status: Keine Dateien ausgewählt</string>
     <string name="select_all">Alle auswählen</string>
     <string name="select_all_files_title">Alle Dateien auswählen?</string>
-    <string name="select_all_files_message">Du bist dabei, alle auf diesem Bildschirm angezeigten Dateien auszuwählen.&#10;&#10;Bist du sicher, dass du fortfahren möchtest?</string>
+    <string name="select_all_files_message">Du bist dabei, alle auf diesem Bildschirm angezeigten Dateien auszuwählen.\n\nBist du sicher, dass du fortfahren möchtest?</string>
     <string name="dont_show_warning_again">Diese Warnung nicht mehr anzeigen</string>
     <string name="delete_confirmation_title">Auswahl löschen</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -209,7 +209,7 @@
     <string name="status_no_files_selected">Status: Keine Dateien ausgewählt</string>
     <string name="select_all">Alle auswählen</string>
     <string name="select_all_files_title">Alle Dateien auswählen?</string>
-    <string name="select_all_files_message">Du bist dabei, alle auf diesem Bildschirm angezeigten Dateien auszuwählen.\\n\\nBist du sicher, dass du fortfahren möchtest?</string>
+    <string name="select_all_files_message">Du bist dabei, alle auf diesem Bildschirm angezeigten Dateien auszuwählen.&#10;&#10;Bist du sicher, dass du fortfahren möchtest?</string>
     <string name="dont_show_warning_again">Diese Warnung nicht mehr anzeigen</string>
     <string name="delete_confirmation_title">Auswahl löschen</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -208,6 +208,9 @@
     </plurals>
     <string name="status_no_files_selected">Status: Keine Dateien ausgewählt</string>
     <string name="select_all">Alle auswählen</string>
+    <string name="select_all_files_title">Alle Dateien auswählen?</string>
+    <string name="select_all_files_message">Du bist dabei, alle auf diesem Bildschirm angezeigten Dateien auszuwählen.\\n\\nBist du sicher, dass du fortfahren möchtest?</string>
+    <string name="dont_show_warning_again">Diese Warnung nicht mehr anzeigen</string>
     <string name="delete_confirmation_title">Auswahl löschen</string>
     <plurals name="delete_confirmation_message">
         <item quantity="one">%1$d Element löschen?</item>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -214,7 +214,7 @@
     <string name="status_no_files_selected">Estado: No hay archivos seleccionados</string>
     <string name="select_all">Seleccionar todo</string>
     <string name="select_all_files_title">¿Seleccionar todos los archivos?</string>
-    <string name="select_all_files_message">Estás a punto de seleccionar todos los archivos mostrados en esta pantalla.&#10;&#10;¿Seguro que deseas continuar?</string>
+    <string name="select_all_files_message">Estás a punto de seleccionar todos los archivos mostrados en esta pantalla.\n\n¿Seguro que deseas continuar?</string>
     <string name="dont_show_warning_again">No volver a mostrar esta advertencia</string>
     <string name="delete_confirmation_title">Eliminar seleccionado</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -213,6 +213,9 @@
     </plurals>
     <string name="status_no_files_selected">Estado: No hay archivos seleccionados</string>
     <string name="select_all">Seleccionar todo</string>
+    <string name="select_all_files_title">¿Seleccionar todos los archivos?</string>
+    <string name="select_all_files_message">Estás a punto de seleccionar todos los archivos mostrados en esta pantalla.\\n\\n¿Seguro que deseas continuar?</string>
+    <string name="dont_show_warning_again">No volver a mostrar esta advertencia</string>
     <string name="delete_confirmation_title">Eliminar seleccionado</string>
     <plurals name="delete_confirmation_message">
         <item quantity="one">¿Eliminar %1$d elemento?</item>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -214,7 +214,7 @@
     <string name="status_no_files_selected">Estado: No hay archivos seleccionados</string>
     <string name="select_all">Seleccionar todo</string>
     <string name="select_all_files_title">¿Seleccionar todos los archivos?</string>
-    <string name="select_all_files_message">Estás a punto de seleccionar todos los archivos mostrados en esta pantalla.\\n\\n¿Seguro que deseas continuar?</string>
+    <string name="select_all_files_message">Estás a punto de seleccionar todos los archivos mostrados en esta pantalla.&#10;&#10;¿Seguro que deseas continuar?</string>
     <string name="dont_show_warning_again">No volver a mostrar esta advertencia</string>
     <string name="delete_confirmation_title">Eliminar seleccionado</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -214,7 +214,7 @@
     <string name="status_no_files_selected">Estado: Ningún archivo seleccionado</string>
     <string name="select_all">Seleccionar todo</string>
     <string name="select_all_files_title">¿Seleccionar todos los archivos?</string>
-    <string name="select_all_files_message">Estás a punto de seleccionar todos los archivos mostrados en esta pantalla.&#10;&#10;¿Seguro que deseas continuar?</string>
+    <string name="select_all_files_message">Estás a punto de seleccionar todos los archivos mostrados en esta pantalla.\n\n¿Seguro que deseas continuar?</string>
     <string name="dont_show_warning_again">No volver a mostrar esta advertencia</string>
     <string name="delete_confirmation_title">Eliminar seleccionado</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -213,6 +213,9 @@
     </plurals>
     <string name="status_no_files_selected">Estado: Ningún archivo seleccionado</string>
     <string name="select_all">Seleccionar todo</string>
+    <string name="select_all_files_title">¿Seleccionar todos los archivos?</string>
+    <string name="select_all_files_message">Estás a punto de seleccionar todos los archivos mostrados en esta pantalla.\\n\\n¿Seguro que deseas continuar?</string>
+    <string name="dont_show_warning_again">No volver a mostrar esta advertencia</string>
     <string name="delete_confirmation_title">Eliminar seleccionado</string>
     <plurals name="delete_confirmation_message">
         <item quantity="one">¿Eliminar %1$d elemento?</item>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -214,7 +214,7 @@
     <string name="status_no_files_selected">Estado: Ningún archivo seleccionado</string>
     <string name="select_all">Seleccionar todo</string>
     <string name="select_all_files_title">¿Seleccionar todos los archivos?</string>
-    <string name="select_all_files_message">Estás a punto de seleccionar todos los archivos mostrados en esta pantalla.\\n\\n¿Seguro que deseas continuar?</string>
+    <string name="select_all_files_message">Estás a punto de seleccionar todos los archivos mostrados en esta pantalla.&#10;&#10;¿Seguro que deseas continuar?</string>
     <string name="dont_show_warning_again">No volver a mostrar esta advertencia</string>
     <string name="delete_confirmation_title">Eliminar seleccionado</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -208,6 +208,9 @@
     </plurals>
     <string name="status_no_files_selected">Katayuan: Walang napiling file</string>
     <string name="select_all">Piliin Lahat</string>
+    <string name="select_all_files_title">Piliin ang Lahat ng File?</string>
+    <string name="select_all_files_message">Pipiliin mo ang lahat ng file na ipinapakita sa screen na ito.\\n\\nSigurado ka bang gusto mong magpatuloy?</string>
+    <string name="dont_show_warning_again">Huwag nang ipakita muli ang babalang ito</string>
     <string name="delete_confirmation_title">Tanggalin ang Napili</string>
     <plurals name="delete_confirmation_message">
         <item quantity="one">Tanggalin ang %1$d item?</item>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -209,7 +209,7 @@
     <string name="status_no_files_selected">Katayuan: Walang napiling file</string>
     <string name="select_all">Piliin Lahat</string>
     <string name="select_all_files_title">Piliin ang Lahat ng File?</string>
-    <string name="select_all_files_message">Pipiliin mo ang lahat ng file na ipinapakita sa screen na ito.&#10;&#10;Sigurado ka bang gusto mong magpatuloy?</string>
+    <string name="select_all_files_message">Pipiliin mo ang lahat ng file na ipinapakita sa screen na ito.\n\nSigurado ka bang gusto mong magpatuloy?</string>
     <string name="dont_show_warning_again">Huwag nang ipakita muli ang babalang ito</string>
     <string name="delete_confirmation_title">Tanggalin ang Napili</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -209,7 +209,7 @@
     <string name="status_no_files_selected">Katayuan: Walang napiling file</string>
     <string name="select_all">Piliin Lahat</string>
     <string name="select_all_files_title">Piliin ang Lahat ng File?</string>
-    <string name="select_all_files_message">Pipiliin mo ang lahat ng file na ipinapakita sa screen na ito.\\n\\nSigurado ka bang gusto mong magpatuloy?</string>
+    <string name="select_all_files_message">Pipiliin mo ang lahat ng file na ipinapakita sa screen na ito.&#10;&#10;Sigurado ka bang gusto mong magpatuloy?</string>
     <string name="dont_show_warning_again">Huwag nang ipakita muli ang babalang ito</string>
     <string name="delete_confirmation_title">Tanggalin ang Napili</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -215,7 +215,7 @@
     <string name="status_no_files_selected">Statut : Aucun fichier sélectionné</string>
     <string name="select_all">Tout sélectionner</string>
     <string name="select_all_files_title">Sélectionner tous les fichiers ?</string>
-    <string name="select_all_files_message">Vous êtes sur le point de sélectionner tous les fichiers affichés sur cet écran.&#10;&#10;Êtes-vous sûr de vouloir continuer ?</string>
+    <string name="select_all_files_message">Vous êtes sur le point de sélectionner tous les fichiers affichés sur cet écran.\n\nÊtes-vous sûr de vouloir continuer ?</string>
     <string name="dont_show_warning_again">Ne plus afficher cet avertissement</string>
     <string name="delete_confirmation_title">Supprimer la sélection</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -215,7 +215,7 @@
     <string name="status_no_files_selected">Statut : Aucun fichier sélectionné</string>
     <string name="select_all">Tout sélectionner</string>
     <string name="select_all_files_title">Sélectionner tous les fichiers ?</string>
-    <string name="select_all_files_message">Vous êtes sur le point de sélectionner tous les fichiers affichés sur cet écran.\\n\\nÊtes-vous sûr de vouloir continuer ?</string>
+    <string name="select_all_files_message">Vous êtes sur le point de sélectionner tous les fichiers affichés sur cet écran.&#10;&#10;Êtes-vous sûr de vouloir continuer ?</string>
     <string name="dont_show_warning_again">Ne plus afficher cet avertissement</string>
     <string name="delete_confirmation_title">Supprimer la sélection</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -214,6 +214,9 @@
 
     <string name="status_no_files_selected">Statut : Aucun fichier sélectionné</string>
     <string name="select_all">Tout sélectionner</string>
+    <string name="select_all_files_title">Sélectionner tous les fichiers ?</string>
+    <string name="select_all_files_message">Vous êtes sur le point de sélectionner tous les fichiers affichés sur cet écran.\\n\\nÊtes-vous sûr de vouloir continuer ?</string>
+    <string name="dont_show_warning_again">Ne plus afficher cet avertissement</string>
     <string name="delete_confirmation_title">Supprimer la sélection</string>
     <plurals name="delete_confirmation_message">
         <item quantity="one">Supprimer %1$d élément ?</item>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -209,7 +209,7 @@
     <string name="status_no_files_selected">स्थिति: कोई फ़ाइल चयनित नहीं</string>
     <string name="select_all">सभी चुनें</string>
     <string name="select_all_files_title">सभी फ़ाइलें चुनें?</string>
-    <string name="select_all_files_message">आप इस स्क्रीन पर दिखाई गई हर फ़ाइल चुनने वाले हैं।&#10;&#10;क्या आप वाकई जारी रखना चाहते हैं?</string>
+    <string name="select_all_files_message">आप इस स्क्रीन पर दिखाई गई हर फ़ाइल चुनने वाले हैं।\n\nक्या आप वाकई जारी रखना चाहते हैं?</string>
     <string name="dont_show_warning_again">यह चेतावनी दोबारा न दिखाएं</string>
     <string name="delete_confirmation_title">चयनित हटाएँ</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -209,7 +209,7 @@
     <string name="status_no_files_selected">स्थिति: कोई फ़ाइल चयनित नहीं</string>
     <string name="select_all">सभी चुनें</string>
     <string name="select_all_files_title">सभी फ़ाइलें चुनें?</string>
-    <string name="select_all_files_message">आप इस स्क्रीन पर दिखाई गई हर फ़ाइल चुनने वाले हैं।\\n\\nक्या आप वाकई जारी रखना चाहते हैं?</string>
+    <string name="select_all_files_message">आप इस स्क्रीन पर दिखाई गई हर फ़ाइल चुनने वाले हैं।&#10;&#10;क्या आप वाकई जारी रखना चाहते हैं?</string>
     <string name="dont_show_warning_again">यह चेतावनी दोबारा न दिखाएं</string>
     <string name="delete_confirmation_title">चयनित हटाएँ</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -208,6 +208,9 @@
     </plurals>
     <string name="status_no_files_selected">स्थिति: कोई फ़ाइल चयनित नहीं</string>
     <string name="select_all">सभी चुनें</string>
+    <string name="select_all_files_title">सभी फ़ाइलें चुनें?</string>
+    <string name="select_all_files_message">आप इस स्क्रीन पर दिखाई गई हर फ़ाइल चुनने वाले हैं।\\n\\nक्या आप वाकई जारी रखना चाहते हैं?</string>
+    <string name="dont_show_warning_again">यह चेतावनी दोबारा न दिखाएं</string>
     <string name="delete_confirmation_title">चयनित हटाएँ</string>
     <plurals name="delete_confirmation_message">
         <item quantity="one">%1$d आइटम हटाएँ?</item>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -209,7 +209,7 @@
     <string name="status_no_files_selected">Állapot: Nincs kiválasztott fájl</string>
     <string name="select_all">Összes kijelölése</string>
     <string name="select_all_files_title">Minden fájl kijelölése?</string>
-    <string name="select_all_files_message">Éppen az összes ezen a képernyőn megjelenített fájlt készül kijelölni.&#10;&#10;Biztosan folytatja?</string>
+    <string name="select_all_files_message">Éppen az összes ezen a képernyőn megjelenített fájlt készül kijelölni.\n\nBiztosan folytatja?</string>
     <string name="dont_show_warning_again">Ne jelenjen meg többé ez a figyelmeztetés</string>
     <string name="delete_confirmation_title">Kiválasztottak törlése</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -209,7 +209,7 @@
     <string name="status_no_files_selected">Állapot: Nincs kiválasztott fájl</string>
     <string name="select_all">Összes kijelölése</string>
     <string name="select_all_files_title">Minden fájl kijelölése?</string>
-    <string name="select_all_files_message">Éppen az összes ezen a képernyőn megjelenített fájlt készül kijelölni.\\n\\nBiztosan folytatja?</string>
+    <string name="select_all_files_message">Éppen az összes ezen a képernyőn megjelenített fájlt készül kijelölni.&#10;&#10;Biztosan folytatja?</string>
     <string name="dont_show_warning_again">Ne jelenjen meg többé ez a figyelmeztetés</string>
     <string name="delete_confirmation_title">Kiválasztottak törlése</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -208,6 +208,9 @@
     </plurals>
     <string name="status_no_files_selected">Állapot: Nincs kiválasztott fájl</string>
     <string name="select_all">Összes kijelölése</string>
+    <string name="select_all_files_title">Minden fájl kijelölése?</string>
+    <string name="select_all_files_message">Éppen az összes ezen a képernyőn megjelenített fájlt készül kijelölni.\\n\\nBiztosan folytatja?</string>
+    <string name="dont_show_warning_again">Ne jelenjen meg többé ez a figyelmeztetés</string>
     <string name="delete_confirmation_title">Kiválasztottak törlése</string>
     <plurals name="delete_confirmation_message">
         <item quantity="one">Töröljem a(z) %1$d elemet?</item>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -204,7 +204,7 @@
     <string name="status_no_files_selected">Status: Tidak ada file yang dipilih</string>
     <string name="select_all">Pilih Semua</string>
     <string name="select_all_files_title">Pilih Semua File?</string>
-    <string name="select_all_files_message">Anda akan memilih semua file yang ditampilkan di layar ini.\\n\\nAnda yakin ingin melanjutkan?</string>
+    <string name="select_all_files_message">Anda akan memilih semua file yang ditampilkan di layar ini.&#10;&#10;Anda yakin ingin melanjutkan?</string>
     <string name="dont_show_warning_again">Jangan tampilkan peringatan ini lagi</string>
     <string name="delete_confirmation_title">Hapus yang Dipilih</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -203,6 +203,9 @@
     </plurals>
     <string name="status_no_files_selected">Status: Tidak ada file yang dipilih</string>
     <string name="select_all">Pilih Semua</string>
+    <string name="select_all_files_title">Pilih Semua File?</string>
+    <string name="select_all_files_message">Anda akan memilih semua file yang ditampilkan di layar ini.\\n\\nAnda yakin ingin melanjutkan?</string>
+    <string name="dont_show_warning_again">Jangan tampilkan peringatan ini lagi</string>
     <string name="delete_confirmation_title">Hapus yang Dipilih</string>
     <plurals name="delete_confirmation_message">
         <item quantity="other">Hapus %1$d item?</item>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -204,7 +204,7 @@
     <string name="status_no_files_selected">Status: Tidak ada file yang dipilih</string>
     <string name="select_all">Pilih Semua</string>
     <string name="select_all_files_title">Pilih Semua File?</string>
-    <string name="select_all_files_message">Anda akan memilih semua file yang ditampilkan di layar ini.&#10;&#10;Anda yakin ingin melanjutkan?</string>
+    <string name="select_all_files_message">Anda akan memilih semua file yang ditampilkan di layar ini.\n\nAnda yakin ingin melanjutkan?</string>
     <string name="dont_show_warning_again">Jangan tampilkan peringatan ini lagi</string>
     <string name="delete_confirmation_title">Hapus yang Dipilih</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -214,7 +214,7 @@
     <string name="status_no_files_selected">Stato: Nessun file selezionato</string>
     <string name="select_all">Seleziona tutto</string>
     <string name="select_all_files_title">Selezionare tutti i file?</string>
-    <string name="select_all_files_message">Stai per selezionare tutti i file mostrati in questa schermata.\\n\\nSei sicuro di voler continuare?</string>
+    <string name="select_all_files_message">Stai per selezionare tutti i file mostrati in questa schermata.&#10;&#10;Sei sicuro di voler continuare?</string>
     <string name="dont_show_warning_again">Non mostrare più questo avviso</string>
     <string name="delete_confirmation_title">Elimina selezionati</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -213,6 +213,9 @@
     </plurals>
     <string name="status_no_files_selected">Stato: Nessun file selezionato</string>
     <string name="select_all">Seleziona tutto</string>
+    <string name="select_all_files_title">Selezionare tutti i file?</string>
+    <string name="select_all_files_message">Stai per selezionare tutti i file mostrati in questa schermata.\\n\\nSei sicuro di voler continuare?</string>
+    <string name="dont_show_warning_again">Non mostrare più questo avviso</string>
     <string name="delete_confirmation_title">Elimina selezionati</string>
     <plurals name="delete_confirmation_message">
         <item quantity="one">Eliminare %1$d elemento?</item>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -214,7 +214,7 @@
     <string name="status_no_files_selected">Stato: Nessun file selezionato</string>
     <string name="select_all">Seleziona tutto</string>
     <string name="select_all_files_title">Selezionare tutti i file?</string>
-    <string name="select_all_files_message">Stai per selezionare tutti i file mostrati in questa schermata.&#10;&#10;Sei sicuro di voler continuare?</string>
+    <string name="select_all_files_message">Stai per selezionare tutti i file mostrati in questa schermata.\n\nSei sicuro di voler continuare?</string>
     <string name="dont_show_warning_again">Non mostrare più questo avviso</string>
     <string name="delete_confirmation_title">Elimina selezionati</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -203,6 +203,9 @@
     </plurals>
     <string name="status_no_files_selected">ステータス: ファイルが選択されていません</string>
     <string name="select_all">すべて選択</string>
+    <string name="select_all_files_title">すべてのファイルを選択しますか？</string>
+    <string name="select_all_files_message">この画面に表示されているすべてのファイルを選択しようとしています。\\n\\n続行してもよろしいですか？</string>
+    <string name="dont_show_warning_again">今後この警告を表示しない</string>
     <string name="delete_confirmation_title">選択項目を削除</string>
     <string name="delete">削除</string>
     <string name="merge">統合</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -204,7 +204,7 @@
     <string name="status_no_files_selected">ステータス: ファイルが選択されていません</string>
     <string name="select_all">すべて選択</string>
     <string name="select_all_files_title">すべてのファイルを選択しますか？</string>
-    <string name="select_all_files_message">この画面に表示されているすべてのファイルを選択しようとしています。\\n\\n続行してもよろしいですか？</string>
+    <string name="select_all_files_message">この画面に表示されているすべてのファイルを選択しようとしています。&#10;&#10;続行してもよろしいですか？</string>
     <string name="dont_show_warning_again">今後この警告を表示しない</string>
     <string name="delete_confirmation_title">選択項目を削除</string>
     <string name="delete">削除</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -204,7 +204,7 @@
     <string name="status_no_files_selected">ステータス: ファイルが選択されていません</string>
     <string name="select_all">すべて選択</string>
     <string name="select_all_files_title">すべてのファイルを選択しますか？</string>
-    <string name="select_all_files_message">この画面に表示されているすべてのファイルを選択しようとしています。&#10;&#10;続行してもよろしいですか？</string>
+    <string name="select_all_files_message">この画面に表示されているすべてのファイルを選択しようとしています。\n\n続行してもよろしいですか？</string>
     <string name="dont_show_warning_again">今後この警告を表示しない</string>
     <string name="delete_confirmation_title">選択項目を削除</string>
     <string name="delete">削除</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -204,7 +204,7 @@
     <string name="status_no_files_selected">상태: 선택된 파일 없음</string>
     <string name="select_all">모두 선택</string>
     <string name="select_all_files_title">모든 파일을 선택하시겠습니까?</string>
-    <string name="select_all_files_message">이 화면에 표시된 모든 파일을 선택하려고 합니다.&#10;&#10;계속하시겠습니까?</string>
+    <string name="select_all_files_message">이 화면에 표시된 모든 파일을 선택하려고 합니다.\n\n계속하시겠습니까?</string>
     <string name="dont_show_warning_again">이 경고를 다시 표시하지 않음</string>
     <string name="delete_confirmation_title">선택 항목 삭제</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -204,7 +204,7 @@
     <string name="status_no_files_selected">상태: 선택된 파일 없음</string>
     <string name="select_all">모두 선택</string>
     <string name="select_all_files_title">모든 파일을 선택하시겠습니까?</string>
-    <string name="select_all_files_message">이 화면에 표시된 모든 파일을 선택하려고 합니다.\\n\\n계속하시겠습니까?</string>
+    <string name="select_all_files_message">이 화면에 표시된 모든 파일을 선택하려고 합니다.&#10;&#10;계속하시겠습니까?</string>
     <string name="dont_show_warning_again">이 경고를 다시 표시하지 않음</string>
     <string name="delete_confirmation_title">선택 항목 삭제</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -203,6 +203,9 @@
     </plurals>
     <string name="status_no_files_selected">상태: 선택된 파일 없음</string>
     <string name="select_all">모두 선택</string>
+    <string name="select_all_files_title">모든 파일을 선택하시겠습니까?</string>
+    <string name="select_all_files_message">이 화면에 표시된 모든 파일을 선택하려고 합니다.\\n\\n계속하시겠습니까?</string>
+    <string name="dont_show_warning_again">이 경고를 다시 표시하지 않음</string>
     <string name="delete_confirmation_title">선택 항목 삭제</string>
     <plurals name="delete_confirmation_message">
         <item quantity="other">%1$d개 항목을 삭제할까요?</item>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -218,6 +218,9 @@
     </plurals>
     <string name="status_no_files_selected">Status: Nie wybrano plików</string>
     <string name="select_all">Zaznacz wszystko</string>
+    <string name="select_all_files_title">Zaznaczyć wszystkie pliki?</string>
+    <string name="select_all_files_message">Zaraz zaznaczysz wszystkie pliki wyświetlane na tym ekranie.\\n\\nCzy na pewno chcesz kontynuować?</string>
+    <string name="dont_show_warning_again">Nie pokazuj ponownie tego ostrzeżenia</string>
     <string name="delete_confirmation_title">Usuń zaznaczone</string>
     <plurals name="delete_confirmation_message">
         <item quantity="one">Usunąć %1$d element?</item>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -219,7 +219,7 @@
     <string name="status_no_files_selected">Status: Nie wybrano plików</string>
     <string name="select_all">Zaznacz wszystko</string>
     <string name="select_all_files_title">Zaznaczyć wszystkie pliki?</string>
-    <string name="select_all_files_message">Zaraz zaznaczysz wszystkie pliki wyświetlane na tym ekranie.&#10;&#10;Czy na pewno chcesz kontynuować?</string>
+    <string name="select_all_files_message">Zaraz zaznaczysz wszystkie pliki wyświetlane na tym ekranie.\n\nCzy na pewno chcesz kontynuować?</string>
     <string name="dont_show_warning_again">Nie pokazuj ponownie tego ostrzeżenia</string>
     <string name="delete_confirmation_title">Usuń zaznaczone</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -219,7 +219,7 @@
     <string name="status_no_files_selected">Status: Nie wybrano plików</string>
     <string name="select_all">Zaznacz wszystko</string>
     <string name="select_all_files_title">Zaznaczyć wszystkie pliki?</string>
-    <string name="select_all_files_message">Zaraz zaznaczysz wszystkie pliki wyświetlane na tym ekranie.\\n\\nCzy na pewno chcesz kontynuować?</string>
+    <string name="select_all_files_message">Zaraz zaznaczysz wszystkie pliki wyświetlane na tym ekranie.&#10;&#10;Czy na pewno chcesz kontynuować?</string>
     <string name="dont_show_warning_again">Nie pokazuj ponownie tego ostrzeżenia</string>
     <string name="delete_confirmation_title">Usuń zaznaczone</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -214,7 +214,7 @@
     <string name="status_no_files_selected">Status: Nenhum arquivo selecionado</string>
     <string name="select_all">Selecionar Tudo</string>
     <string name="select_all_files_title">Selecionar todos os arquivos?</string>
-    <string name="select_all_files_message">Você está prestes a selecionar todos os arquivos exibidos nesta tela.\\n\\nTem certeza de que deseja continuar?</string>
+    <string name="select_all_files_message">Você está prestes a selecionar todos os arquivos exibidos nesta tela.&#10;&#10;Tem certeza de que deseja continuar?</string>
     <string name="dont_show_warning_again">Não mostrar este aviso novamente</string>
     <string name="delete_confirmation_title">Excluir selecionados</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -214,7 +214,7 @@
     <string name="status_no_files_selected">Status: Nenhum arquivo selecionado</string>
     <string name="select_all">Selecionar Tudo</string>
     <string name="select_all_files_title">Selecionar todos os arquivos?</string>
-    <string name="select_all_files_message">Você está prestes a selecionar todos os arquivos exibidos nesta tela.&#10;&#10;Tem certeza de que deseja continuar?</string>
+    <string name="select_all_files_message">Você está prestes a selecionar todos os arquivos exibidos nesta tela.\n\nTem certeza de que deseja continuar?</string>
     <string name="dont_show_warning_again">Não mostrar este aviso novamente</string>
     <string name="delete_confirmation_title">Excluir selecionados</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -213,6 +213,9 @@
     </plurals>
     <string name="status_no_files_selected">Status: Nenhum arquivo selecionado</string>
     <string name="select_all">Selecionar Tudo</string>
+    <string name="select_all_files_title">Selecionar todos os arquivos?</string>
+    <string name="select_all_files_message">Você está prestes a selecionar todos os arquivos exibidos nesta tela.\\n\\nTem certeza de que deseja continuar?</string>
+    <string name="dont_show_warning_again">Não mostrar este aviso novamente</string>
     <string name="delete_confirmation_title">Excluir selecionados</string>
     <plurals name="delete_confirmation_message">
         <item quantity="one">Excluir %1$d item?</item>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -214,7 +214,7 @@
     <string name="status_no_files_selected">Stare: Niciun fișier selectat</string>
     <string name="select_all">Selectează tot</string>
     <string name="select_all_files_title">Selectezi toate fișierele?</string>
-    <string name="select_all_files_message">Ești pe cale să selectezi toate fișierele afișate pe acest ecran.\\n\\nSigur vrei să continui?</string>
+    <string name="select_all_files_message">Ești pe cale să selectezi toate fișierele afișate pe acest ecran.&#10;&#10;Sigur vrei să continui?</string>
     <string name="dont_show_warning_again">Nu mai afișa acest avertisment</string>
     <string name="delete_confirmation_title">Șterge selectate</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -213,6 +213,9 @@
     </plurals>
     <string name="status_no_files_selected">Stare: Niciun fișier selectat</string>
     <string name="select_all">Selectează tot</string>
+    <string name="select_all_files_title">Selectezi toate fișierele?</string>
+    <string name="select_all_files_message">Ești pe cale să selectezi toate fișierele afișate pe acest ecran.\\n\\nSigur vrei să continui?</string>
+    <string name="dont_show_warning_again">Nu mai afișa acest avertisment</string>
     <string name="delete_confirmation_title">Șterge selectate</string>
     <plurals name="delete_confirmation_message">
         <item quantity="one">Șterge %1$d element?</item>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -214,7 +214,7 @@
     <string name="status_no_files_selected">Stare: Niciun fișier selectat</string>
     <string name="select_all">Selectează tot</string>
     <string name="select_all_files_title">Selectezi toate fișierele?</string>
-    <string name="select_all_files_message">Ești pe cale să selectezi toate fișierele afișate pe acest ecran.&#10;&#10;Sigur vrei să continui?</string>
+    <string name="select_all_files_message">Ești pe cale să selectezi toate fișierele afișate pe acest ecran.\n\nSigur vrei să continui?</string>
     <string name="dont_show_warning_again">Nu mai afișa acest avertisment</string>
     <string name="delete_confirmation_title">Șterge selectate</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -218,6 +218,9 @@
     </plurals>
     <string name="status_no_files_selected">Статус: Файлы не выбраны</string>
     <string name="select_all">Выбрать все</string>
+    <string name="select_all_files_title">Выбрать все файлы?</string>
+    <string name="select_all_files_message">Вы собираетесь выбрать все файлы, показанные на этом экране.\\n\\nВы уверены, что хотите продолжить?</string>
+    <string name="dont_show_warning_again">Больше не показывать это предупреждение</string>
     <string name="delete_confirmation_title">Удалить выбранное</string>
     <plurals name="delete_confirmation_message">
         <item quantity="one">Удалить %1$d элемент?</item>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -219,7 +219,7 @@
     <string name="status_no_files_selected">Статус: Файлы не выбраны</string>
     <string name="select_all">Выбрать все</string>
     <string name="select_all_files_title">Выбрать все файлы?</string>
-    <string name="select_all_files_message">Вы собираетесь выбрать все файлы, показанные на этом экране.\\n\\nВы уверены, что хотите продолжить?</string>
+    <string name="select_all_files_message">Вы собираетесь выбрать все файлы, показанные на этом экране.&#10;&#10;Вы уверены, что хотите продолжить?</string>
     <string name="dont_show_warning_again">Больше не показывать это предупреждение</string>
     <string name="delete_confirmation_title">Удалить выбранное</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -219,7 +219,7 @@
     <string name="status_no_files_selected">Статус: Файлы не выбраны</string>
     <string name="select_all">Выбрать все</string>
     <string name="select_all_files_title">Выбрать все файлы?</string>
-    <string name="select_all_files_message">Вы собираетесь выбрать все файлы, показанные на этом экране.&#10;&#10;Вы уверены, что хотите продолжить?</string>
+    <string name="select_all_files_message">Вы собираетесь выбрать все файлы, показанные на этом экране.\n\nВы уверены, что хотите продолжить?</string>
     <string name="dont_show_warning_again">Больше не показывать это предупреждение</string>
     <string name="delete_confirmation_title">Удалить выбранное</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -209,7 +209,7 @@
     <string name="status_no_files_selected">Status: Inga filer valda</string>
     <string name="select_all">Välj alla</string>
     <string name="select_all_files_title">Välj alla filer?</string>
-    <string name="select_all_files_message">Du är på väg att välja alla filer som visas på den här skärmen.\\n\\nÄr du säker på att du vill fortsätta?</string>
+    <string name="select_all_files_message">Du är på väg att välja alla filer som visas på den här skärmen.&#10;&#10;Är du säker på att du vill fortsätta?</string>
     <string name="dont_show_warning_again">Visa inte den här varningen igen</string>
     <string name="delete_confirmation_title">Ta bort markerade</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -209,7 +209,7 @@
     <string name="status_no_files_selected">Status: Inga filer valda</string>
     <string name="select_all">Välj alla</string>
     <string name="select_all_files_title">Välj alla filer?</string>
-    <string name="select_all_files_message">Du är på väg att välja alla filer som visas på den här skärmen.&#10;&#10;Är du säker på att du vill fortsätta?</string>
+    <string name="select_all_files_message">Du är på väg att välja alla filer som visas på den här skärmen.\n\nÄr du säker på att du vill fortsätta?</string>
     <string name="dont_show_warning_again">Visa inte den här varningen igen</string>
     <string name="delete_confirmation_title">Ta bort markerade</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -208,6 +208,9 @@
     </plurals>
     <string name="status_no_files_selected">Status: Inga filer valda</string>
     <string name="select_all">Välj alla</string>
+    <string name="select_all_files_title">Välj alla filer?</string>
+    <string name="select_all_files_message">Du är på väg att välja alla filer som visas på den här skärmen.\\n\\nÄr du säker på att du vill fortsätta?</string>
+    <string name="dont_show_warning_again">Visa inte den här varningen igen</string>
     <string name="delete_confirmation_title">Ta bort markerade</string>
     <plurals name="delete_confirmation_message">
         <item quantity="one">Ta bort %1$d objekt?</item>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -204,7 +204,7 @@
     <string name="status_no_files_selected">สถานะ: ไม่ได้เลือกไฟล์</string>
     <string name="select_all">เลือกทั้งหมด</string>
     <string name="select_all_files_title">เลือกไฟล์ทั้งหมดหรือไม่?</string>
-    <string name="select_all_files_message">คุณกำลังจะเลือกไฟล์ทั้งหมดที่แสดงบนหน้าจอนี้\\n\\nแน่ใจหรือไม่ว่าต้องการดำเนินการต่อ?</string>
+    <string name="select_all_files_message">คุณกำลังจะเลือกไฟล์ทั้งหมดที่แสดงบนหน้าจอนี้&#10;&#10;แน่ใจหรือไม่ว่าต้องการดำเนินการต่อ?</string>
     <string name="dont_show_warning_again">ไม่ต้องแสดงคำเตือนนี้อีก</string>
     <string name="delete_confirmation_title">ลบที่เลือก</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -204,7 +204,7 @@
     <string name="status_no_files_selected">สถานะ: ไม่ได้เลือกไฟล์</string>
     <string name="select_all">เลือกทั้งหมด</string>
     <string name="select_all_files_title">เลือกไฟล์ทั้งหมดหรือไม่?</string>
-    <string name="select_all_files_message">คุณกำลังจะเลือกไฟล์ทั้งหมดที่แสดงบนหน้าจอนี้&#10;&#10;แน่ใจหรือไม่ว่าต้องการดำเนินการต่อ?</string>
+    <string name="select_all_files_message">คุณกำลังจะเลือกไฟล์ทั้งหมดที่แสดงบนหน้าจอนี้\n\nแน่ใจหรือไม่ว่าต้องการดำเนินการต่อ?</string>
     <string name="dont_show_warning_again">ไม่ต้องแสดงคำเตือนนี้อีก</string>
     <string name="delete_confirmation_title">ลบที่เลือก</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -203,6 +203,9 @@
     </plurals>
     <string name="status_no_files_selected">สถานะ: ไม่ได้เลือกไฟล์</string>
     <string name="select_all">เลือกทั้งหมด</string>
+    <string name="select_all_files_title">เลือกไฟล์ทั้งหมดหรือไม่?</string>
+    <string name="select_all_files_message">คุณกำลังจะเลือกไฟล์ทั้งหมดที่แสดงบนหน้าจอนี้\\n\\nแน่ใจหรือไม่ว่าต้องการดำเนินการต่อ?</string>
+    <string name="dont_show_warning_again">ไม่ต้องแสดงคำเตือนนี้อีก</string>
     <string name="delete_confirmation_title">ลบที่เลือก</string>
     <plurals name="delete_confirmation_message">
         <item quantity="other">ลบ %1$d รายการหรือไม่?</item>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -209,7 +209,7 @@
     <string name="status_no_files_selected">Durum: Hiçbir dosya seçilmedi</string>
     <string name="select_all">Tümünü Seç</string>
     <string name="select_all_files_title">Tüm dosyalar seçilsin mi?</string>
-    <string name="select_all_files_message">Bu ekranda gösterilen tüm dosyaları seçmek üzeresiniz.&#10;&#10;Devam etmek istediğinizden emin misiniz?</string>
+    <string name="select_all_files_message">Bu ekranda gösterilen tüm dosyaları seçmek üzeresiniz.\n\nDevam etmek istediğinizden emin misiniz?</string>
     <string name="dont_show_warning_again">Bu uyarıyı bir daha gösterme</string>
     <string name="delete_confirmation_title">Seçilenleri Sil</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -209,7 +209,7 @@
     <string name="status_no_files_selected">Durum: Hiçbir dosya seçilmedi</string>
     <string name="select_all">Tümünü Seç</string>
     <string name="select_all_files_title">Tüm dosyalar seçilsin mi?</string>
-    <string name="select_all_files_message">Bu ekranda gösterilen tüm dosyaları seçmek üzeresiniz.\\n\\nDevam etmek istediğinizden emin misiniz?</string>
+    <string name="select_all_files_message">Bu ekranda gösterilen tüm dosyaları seçmek üzeresiniz.&#10;&#10;Devam etmek istediğinizden emin misiniz?</string>
     <string name="dont_show_warning_again">Bu uyarıyı bir daha gösterme</string>
     <string name="delete_confirmation_title">Seçilenleri Sil</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -208,6 +208,9 @@
     </plurals>
     <string name="status_no_files_selected">Durum: Hiçbir dosya seçilmedi</string>
     <string name="select_all">Tümünü Seç</string>
+    <string name="select_all_files_title">Tüm dosyalar seçilsin mi?</string>
+    <string name="select_all_files_message">Bu ekranda gösterilen tüm dosyaları seçmek üzeresiniz.\\n\\nDevam etmek istediğinizden emin misiniz?</string>
+    <string name="dont_show_warning_again">Bu uyarıyı bir daha gösterme</string>
     <string name="delete_confirmation_title">Seçilenleri Sil</string>
     <plurals name="delete_confirmation_message">
         <item quantity="one">%1$d öğeyi sil?</item>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -219,7 +219,7 @@
     <string name="status_no_files_selected">Статус: Файли не вибрано</string>
     <string name="select_all">Вибрати все</string>
     <string name="select_all_files_title">Вибрати всі файли?</string>
-    <string name="select_all_files_message">Ви збираєтеся вибрати всі файли, показані на цьому екрані.&#10;&#10;Ви впевнені, що хочете продовжити?</string>
+    <string name="select_all_files_message">Ви збираєтеся вибрати всі файли, показані на цьому екрані.\n\nВи впевнені, що хочете продовжити?</string>
     <string name="dont_show_warning_again">Більше не показувати це попередження</string>
     <string name="delete_confirmation_title">Видалити вибране</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -219,7 +219,7 @@
     <string name="status_no_files_selected">Статус: Файли не вибрано</string>
     <string name="select_all">Вибрати все</string>
     <string name="select_all_files_title">Вибрати всі файли?</string>
-    <string name="select_all_files_message">Ви збираєтеся вибрати всі файли, показані на цьому екрані.\\n\\nВи впевнені, що хочете продовжити?</string>
+    <string name="select_all_files_message">Ви збираєтеся вибрати всі файли, показані на цьому екрані.&#10;&#10;Ви впевнені, що хочете продовжити?</string>
     <string name="dont_show_warning_again">Більше не показувати це попередження</string>
     <string name="delete_confirmation_title">Видалити вибране</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -218,6 +218,9 @@
     </plurals>
     <string name="status_no_files_selected">Статус: Файли не вибрано</string>
     <string name="select_all">Вибрати все</string>
+    <string name="select_all_files_title">Вибрати всі файли?</string>
+    <string name="select_all_files_message">Ви збираєтеся вибрати всі файли, показані на цьому екрані.\\n\\nВи впевнені, що хочете продовжити?</string>
+    <string name="dont_show_warning_again">Більше не показувати це попередження</string>
     <string name="delete_confirmation_title">Видалити вибране</string>
     <plurals name="delete_confirmation_message">
         <item quantity="one">Видалити %1$d елемент?</item>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -208,6 +208,9 @@
     </plurals>
     <string name="status_no_files_selected">حیثیت: کوئی فائل منتخب نہیں کی گئی</string>
     <string name="select_all">سب کو منتخب کریں</string>
+    <string name="select_all_files_title">تمام فائلیں منتخب کریں؟</string>
+    <string name="select_all_files_message">آپ اس اسکرین پر دکھائی جانے والی تمام فائلیں منتخب کرنے والے ہیں۔\\n\\nکیا آپ واقعی جاری رکھنا چاہتے ہیں؟</string>
+    <string name="dont_show_warning_again">یہ انتباہ دوبارہ نہ دکھائیں</string>
     <string name="delete_confirmation_title">منتخب حذف کریں</string>
     <plurals name="delete_confirmation_message">
         <item quantity="one">کیا %1$d آئٹم حذف کریں؟</item>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -209,7 +209,7 @@
     <string name="status_no_files_selected">حیثیت: کوئی فائل منتخب نہیں کی گئی</string>
     <string name="select_all">سب کو منتخب کریں</string>
     <string name="select_all_files_title">تمام فائلیں منتخب کریں؟</string>
-    <string name="select_all_files_message">آپ اس اسکرین پر دکھائی جانے والی تمام فائلیں منتخب کرنے والے ہیں۔\\n\\nکیا آپ واقعی جاری رکھنا چاہتے ہیں؟</string>
+    <string name="select_all_files_message">آپ اس اسکرین پر دکھائی جانے والی تمام فائلیں منتخب کرنے والے ہیں۔&#10;&#10;کیا آپ واقعی جاری رکھنا چاہتے ہیں؟</string>
     <string name="dont_show_warning_again">یہ انتباہ دوبارہ نہ دکھائیں</string>
     <string name="delete_confirmation_title">منتخب حذف کریں</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -209,7 +209,7 @@
     <string name="status_no_files_selected">حیثیت: کوئی فائل منتخب نہیں کی گئی</string>
     <string name="select_all">سب کو منتخب کریں</string>
     <string name="select_all_files_title">تمام فائلیں منتخب کریں؟</string>
-    <string name="select_all_files_message">آپ اس اسکرین پر دکھائی جانے والی تمام فائلیں منتخب کرنے والے ہیں۔&#10;&#10;کیا آپ واقعی جاری رکھنا چاہتے ہیں؟</string>
+    <string name="select_all_files_message">آپ اس اسکرین پر دکھائی جانے والی تمام فائلیں منتخب کرنے والے ہیں۔\n\nکیا آپ واقعی جاری رکھنا چاہتے ہیں؟</string>
     <string name="dont_show_warning_again">یہ انتباہ دوبارہ نہ دکھائیں</string>
     <string name="delete_confirmation_title">منتخب حذف کریں</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -204,7 +204,7 @@
     <string name="status_no_files_selected">Trạng thái: Chưa chọn tệp nào</string>
     <string name="select_all">Chọn tất cả</string>
     <string name="select_all_files_title">Chọn tất cả tệp?</string>
-    <string name="select_all_files_message">Bạn sắp chọn tất cả các tệp hiển thị trên màn hình này.\\n\\nBạn có chắc muốn tiếp tục không?</string>
+    <string name="select_all_files_message">Bạn sắp chọn tất cả các tệp hiển thị trên màn hình này.&#10;&#10;Bạn có chắc muốn tiếp tục không?</string>
     <string name="dont_show_warning_again">Không hiện lại cảnh báo này</string>
     <string name="delete_confirmation_title">Xóa đã chọn</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -203,6 +203,9 @@
     </plurals>
     <string name="status_no_files_selected">Trạng thái: Chưa chọn tệp nào</string>
     <string name="select_all">Chọn tất cả</string>
+    <string name="select_all_files_title">Chọn tất cả tệp?</string>
+    <string name="select_all_files_message">Bạn sắp chọn tất cả các tệp hiển thị trên màn hình này.\\n\\nBạn có chắc muốn tiếp tục không?</string>
+    <string name="dont_show_warning_again">Không hiện lại cảnh báo này</string>
     <string name="delete_confirmation_title">Xóa đã chọn</string>
     <plurals name="delete_confirmation_message">
         <item quantity="other">Xóa %1$d mục?</item>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -204,7 +204,7 @@
     <string name="status_no_files_selected">Trạng thái: Chưa chọn tệp nào</string>
     <string name="select_all">Chọn tất cả</string>
     <string name="select_all_files_title">Chọn tất cả tệp?</string>
-    <string name="select_all_files_message">Bạn sắp chọn tất cả các tệp hiển thị trên màn hình này.&#10;&#10;Bạn có chắc muốn tiếp tục không?</string>
+    <string name="select_all_files_message">Bạn sắp chọn tất cả các tệp hiển thị trên màn hình này.\n\nBạn có chắc muốn tiếp tục không?</string>
     <string name="dont_show_warning_again">Không hiện lại cảnh báo này</string>
     <string name="delete_confirmation_title">Xóa đã chọn</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -204,7 +204,7 @@
     <string name="status_no_files_selected">狀態：未選取任何檔案</string>
     <string name="select_all">全選</string>
     <string name="select_all_files_title">選取所有檔案？</string>
-    <string name="select_all_files_message">您即將選取此畫面上顯示的所有檔案。&#10;&#10;確定要繼續嗎？</string>
+    <string name="select_all_files_message">您即將選取此畫面上顯示的所有檔案。\n\n確定要繼續嗎？</string>
     <string name="dont_show_warning_again">不再顯示此警告</string>
     <string name="delete_confirmation_title">刪除所選</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -204,7 +204,7 @@
     <string name="status_no_files_selected">狀態：未選取任何檔案</string>
     <string name="select_all">全選</string>
     <string name="select_all_files_title">選取所有檔案？</string>
-    <string name="select_all_files_message">您即將選取此畫面上顯示的所有檔案。\\n\\n確定要繼續嗎？</string>
+    <string name="select_all_files_message">您即將選取此畫面上顯示的所有檔案。&#10;&#10;確定要繼續嗎？</string>
     <string name="dont_show_warning_again">不再顯示此警告</string>
     <string name="delete_confirmation_title">刪除所選</string>
     <plurals name="delete_confirmation_message">

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -203,6 +203,9 @@
     </plurals>
     <string name="status_no_files_selected">狀態：未選取任何檔案</string>
     <string name="select_all">全選</string>
+    <string name="select_all_files_title">選取所有檔案？</string>
+    <string name="select_all_files_message">您即將選取此畫面上顯示的所有檔案。\\n\\n確定要繼續嗎？</string>
+    <string name="dont_show_warning_again">不再顯示此警告</string>
     <string name="delete_confirmation_title">刪除所選</string>
     <plurals name="delete_confirmation_message">
         <item quantity="other">要刪除 %1$d 個項目嗎？</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -211,8 +211,8 @@
     <string name="status_no_files_selected">Status: No files selected</string>
     <string name="select_all">Select All</string>
     <string name="select_all_files_title">Select All Files?</string>
-    <string name="select_all_files_message">You're about to select every file shown on this screen.\n\nAre you sure you want to continue?</string>
-    <string name="dont_show_warning_again">Don't show this warning again</string>
+    <string name="select_all_files_message">You&#39;re about to select every file shown on this screen.&#10;&#10;Are you sure you want to continue?</string>
+    <string name="dont_show_warning_again">Don&#39;t show this warning again</string>
     <string name="delete_confirmation_title">Delete Selected</string>
     <plurals name="delete_confirmation_message">
         <item quantity="one">Delete %1$d item?</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -212,7 +212,7 @@
     <string name="select_all">Select All</string>
     <string name="select_all_files_title">Select All Files?</string>
     <string name="select_all_files_message">You're about to select every file shown on this screen.\n\nAre you sure you want to continue?</string>
-    <string name="dont_show_again">Don't show this warning again</string>
+    <string name="dont_show_warning_again">Don't show this warning again</string>
     <string name="delete_confirmation_title">Delete Selected</string>
     <plurals name="delete_confirmation_message">
         <item quantity="one">Delete %1$d item?</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -211,8 +211,8 @@
     <string name="status_no_files_selected">Status: No files selected</string>
     <string name="select_all">Select All</string>
     <string name="select_all_files_title">Select All Files?</string>
-    <string name="select_all_files_message">You&#39;re about to select every file shown on this screen.&#10;&#10;Are you sure you want to continue?</string>
-    <string name="dont_show_warning_again">Don&#39;t show this warning again</string>
+    <string name="select_all_files_message">You\'re about to select every file shown on this screen.\n\nAre you sure you want to continue?</string>
+    <string name="dont_show_warning_again">Don\'t show this warning again</string>
     <string name="delete_confirmation_title">Delete Selected</string>
     <plurals name="delete_confirmation_message">
         <item quantity="one">Delete %1$d item?</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -210,6 +210,9 @@
     </plurals>
     <string name="status_no_files_selected">Status: No files selected</string>
     <string name="select_all">Select All</string>
+    <string name="select_all_files_title">Select All Files?</string>
+    <string name="select_all_files_message">You're about to select every file shown on this screen.\n\nAre you sure you want to continue?</string>
+    <string name="dont_show_again">Don't show this warning again</string>
     <string name="delete_confirmation_title">Delete Selected</string>
     <plurals name="delete_confirmation_message">
         <item quantity="one">Delete %1$d item?</item>


### PR DESCRIPTION
## Summary
- warn before globally selecting files
- allow disabling future warnings
- persist user preference in DataStore

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894d8ec52ec832d8544ba604101cf7f