### PR TITLE
Group storage grids inside cards

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/components/MemoryManagerShimmer.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/components/MemoryManagerShimmer.kt
@@ -4,6 +4,8 @@ import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -19,14 +21,12 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
@@ -190,49 +190,59 @@ private fun CarouselShimmerCard(pageOffset: Float) {
 
 @Composable
 private fun StorageBreakdownGridShimmer() {
-    Card(
+    Box(
         modifier = Modifier
             .fillMaxWidth()
-            .animateContentSize()
-            .padding(horizontal = SizeConstants.MediumSize),
-        shape = RoundedCornerShape(SizeConstants.MediumSize),
-        colors = CardDefaults.cardColors(containerColor = Color.Transparent),
+            .padding(SizeConstants.MediumSize)
+            .animateContentSize(),
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(SizeConstants.ExtraTinySize)
+                .clip(RoundedCornerShape(SizeConstants.LargeIncreasedSize))
         ) {
-            repeat(3) {
+            Column(verticalArrangement = Arrangement.spacedBy(SizeConstants.ExtraTinySize)) {
+                repeat(3) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .animateContentSize(),
+                        horizontalArrangement = Arrangement.spacedBy(
+                            space = SizeConstants.ExtraTinySize,
+                            alignment = Alignment.CenterHorizontally
+                        ),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        StorageBreakdownItemShimmer(modifier = Modifier.weight(1f))
+                        StorageBreakdownItemShimmer(modifier = Modifier.weight(1f))
+                    }
+                }
                 Row(
                     modifier = Modifier
-                        .fillMaxWidth(),
+                        .fillMaxWidth()
+                        .animateContentSize(),
+                    horizontalArrangement = Arrangement.spacedBy(
+                        space = SizeConstants.ExtraTinySize,
+                        alignment = Alignment.CenterHorizontally
+                    ),
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
-                    StorageBreakdownItemShimmer(modifier = Modifier.weight(1f))
-
-                    StorageBreakdownItemShimmer(modifier = Modifier.weight(1f))
+                    StorageBreakdownItemShimmer(modifier = Modifier.fillMaxWidth())
                 }
-            }
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth(),
-            ) {
-                StorageBreakdownItemShimmer(modifier = Modifier.fillMaxWidth())
             }
         }
     }
 }
+
 private fun StorageBreakdownItemShimmer(modifier: Modifier = Modifier) {
     Card(
-        modifier = modifier
-            .padding(all = SizeConstants.ExtraTinySize),
+        modifier = modifier,
         shape = RoundedCornerShape(SizeConstants.ExtraTinySize),
-        colors = CardDefaults.cardColors(containerColor = Color.Transparent),
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(all = SizeConstants.ExtraTinySize),
+                .padding(all = SizeConstants.LargeSize),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Spacer(
@@ -263,5 +273,4 @@ private fun StorageBreakdownItemShimmer(modifier: Modifier = Modifier) {
             }
         }
     }
-}
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/components/MemoryManagerShimmer.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/components/MemoryManagerShimmer.kt
@@ -234,6 +234,7 @@ private fun StorageBreakdownGridShimmer() {
     }
 }
 
+@Composable
 private fun StorageBreakdownItemShimmer(modifier: Modifier = Modifier) {
     Card(
         modifier = modifier,

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/components/MemoryManagerShimmer.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/components/MemoryManagerShimmer.kt
@@ -19,19 +19,21 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
 import com.d4rk.android.libs.apptoolkit.core.ui.components.carousel.DotsIndicator
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.hapticPagerSwipe
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.shimmerEffect
-import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.ExtraSmallHorizontalSpacer
+import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.ExtraTinyHorizontalSpacer
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.ExtraTinyVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.MediumVerticalSpacer
@@ -188,53 +190,59 @@ private fun CarouselShimmerCard(pageOffset: Float) {
 
 @Composable
 private fun StorageBreakdownGridShimmer() {
-    Column(
+    Card(
         modifier = Modifier
             .fillMaxWidth()
             .animateContentSize()
-            .padding(horizontal = SizeConstants.MediumSize)
+            .padding(horizontal = SizeConstants.MediumSize),
+        shape = RoundedCornerShape(SizeConstants.MediumSize),
+        colors = CardDefaults.cardColors(containerColor = Color.Transparent),
     ) {
-        repeat(3) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-
-            ) {
-                StorageBreakdownItemShimmer(modifier = Modifier.weight(1f))
-
-                StorageBreakdownItemShimmer(modifier = Modifier.weight(1f))
-            }
-
-        }
-        Row(
+        Column(
             modifier = Modifier
                 .fillMaxWidth()
+                .padding(SizeConstants.ExtraTinySize)
         ) {
-            StorageBreakdownItemShimmer(modifier = Modifier.fillMaxWidth())
+            repeat(3) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth(),
+                ) {
+                    StorageBreakdownItemShimmer(modifier = Modifier.weight(1f))
+
+                    StorageBreakdownItemShimmer(modifier = Modifier.weight(1f))
+                }
+            }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth(),
+            ) {
+                StorageBreakdownItemShimmer(modifier = Modifier.fillMaxWidth())
+            }
         }
     }
 }
-
-@Composable
 private fun StorageBreakdownItemShimmer(modifier: Modifier = Modifier) {
     Card(
         modifier = modifier
-            .padding(all = SizeConstants.ExtraSmallSize),
+            .padding(all = SizeConstants.ExtraTinySize),
+        shape = RoundedCornerShape(SizeConstants.ExtraTinySize),
+        colors = CardDefaults.cardColors(containerColor = Color.Transparent),
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(all = SizeConstants.LargeSize),
+                .padding(all = SizeConstants.ExtraTinySize),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Spacer(
                 modifier = Modifier
                     .size(48.dp)
                     .clip(RoundedCornerShape(SizeConstants.MediumSize))
-                    .shimmerEffect()
+                    .shimmerEffect(),
             )
 
-            ExtraSmallHorizontalSpacer()
+            ExtraTinyHorizontalSpacer()
 
             Column {
                 Spacer(
@@ -242,7 +250,7 @@ private fun StorageBreakdownItemShimmer(modifier: Modifier = Modifier) {
                         .fillMaxWidth(0.8f)
                         .height(MaterialTheme.typography.bodyMedium.lineHeight.value.dp)
                         .clip(RoundedCornerShape(SizeConstants.ExtraSmallSize))
-                        .shimmerEffect()
+                        .shimmerEffect(),
                 )
                 ExtraTinyVerticalSpacer()
                 Spacer(
@@ -250,9 +258,10 @@ private fun StorageBreakdownItemShimmer(modifier: Modifier = Modifier) {
                         .fillMaxWidth(0.6f)
                         .height(MaterialTheme.typography.bodySmall.lineHeight.value.dp)
                         .clip(RoundedCornerShape(SizeConstants.ExtraSmallSize))
-                        .shimmerEffect()
+                        .shimmerEffect(),
                 )
             }
         }
     }
+}
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/components/StorageBreakdownGrid.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/components/StorageBreakdownGrid.kt
@@ -1,16 +1,17 @@
 package com.d4rk.cleaner.app.clean.memory.ui.components
 
 import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.draw.clip
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
 @Composable
@@ -18,37 +19,43 @@ fun StorageBreakdownGrid(
     storageBreakdown: Map<String, Long>,
     onItemClick: (String) -> Unit = {},
 ) {
-    Card(
+    Box(
         modifier = Modifier
             .fillMaxWidth()
-            .animateContentSize()
-            .padding(horizontal = SizeConstants.MediumSize),
-        shape = RoundedCornerShape(SizeConstants.MediumSize),
-        colors = CardDefaults.cardColors(containerColor = Color.Transparent),
+            .padding(SizeConstants.MediumSize)
+            .animateContentSize(),
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(SizeConstants.ExtraTinySize)
+                .clip(RoundedCornerShape(SizeConstants.LargeIncreasedSize))
         ) {
-            storageBreakdown.entries.toList().chunked(size = 2)
-                .forEach { chunk: List<Map.Entry<String, Long>> ->
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .animateContentSize(),
-                    ) {
-                        for (item: Map.Entry<String, Long> in chunk) {
-                            val (icon: String, size: Long) = item
-                            StorageBreakdownItem(
-                                icon = icon,
-                                size = size,
-                                modifier = Modifier.weight(1f),
-                                onClick = { onItemClick(icon) }
-                            )
+            Column(verticalArrangement = Arrangement.spacedBy(SizeConstants.ExtraTinySize)) {
+                storageBreakdown.entries.toList().chunked(size = 2)
+                    .forEach { chunk: List<Map.Entry<String, Long>> ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .animateContentSize(),
+                            horizontalArrangement = Arrangement.spacedBy(
+                                space = SizeConstants.ExtraTinySize,
+                                alignment = Alignment.CenterHorizontally
+                            ),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            for (item: Map.Entry<String, Long> in chunk) {
+                                val (icon: String, size: Long) = item
+                                StorageBreakdownItem(
+                                    icon = icon,
+                                    size = size,
+                                    modifier = Modifier.weight(1f),
+                                    onClick = { onItemClick(icon) }
+                                )
+                            }
                         }
                     }
-                }
+            }
         }
     }
 }
+

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/components/StorageBreakdownGrid.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/components/StorageBreakdownGrid.kt
@@ -5,38 +5,50 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
 @Composable
 fun StorageBreakdownGrid(
     storageBreakdown: Map<String, Long>,
-    onItemClick: (String) -> Unit = {}
+    onItemClick: (String) -> Unit = {},
 ) {
-    Column(
+    Card(
         modifier = Modifier
             .fillMaxWidth()
             .animateContentSize()
-            .padding(horizontal = SizeConstants.MediumSize)
+            .padding(horizontal = SizeConstants.MediumSize),
+        shape = RoundedCornerShape(SizeConstants.MediumSize),
+        colors = CardDefaults.cardColors(containerColor = Color.Transparent),
     ) {
-        storageBreakdown.entries.toList().chunked(size = 2)
-            .forEach { chunk: List<Map.Entry<String, Long>> ->
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .animateContentSize()
-                ) {
-                    for (item: Map.Entry<String, Long> in chunk) {
-                        val (icon: String, size: Long) = item
-                        StorageBreakdownItem(
-                            icon = icon,
-                            size = size,
-                            modifier = Modifier.weight(weight = 1f),
-                            onClick = { onItemClick(icon) }
-                        )
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(SizeConstants.ExtraTinySize)
+        ) {
+            storageBreakdown.entries.toList().chunked(size = 2)
+                .forEach { chunk: List<Map.Entry<String, Long>> ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .animateContentSize(),
+                    ) {
+                        for (item: Map.Entry<String, Long> in chunk) {
+                            val (icon: String, size: Long) = item
+                            StorageBreakdownItem(
+                                icon = icon,
+                                size = size,
+                                modifier = Modifier.weight(1f),
+                                onClick = { onItemClick(icon) }
+                            )
+                        }
                     }
                 }
-            }
+        }
     }
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/components/StorageBreakdownItem.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/components/StorageBreakdownItem.kt
@@ -26,12 +26,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
-import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.ExtraSmallHorizontalSpacer
+import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.ExtraTinyHorizontalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.cleaner.R
 import com.d4rk.cleaner.core.utils.helpers.FileSizeFormatter.format as formatSize
@@ -54,16 +55,17 @@ fun StorageBreakdownItem(
     )
     Card(
         modifier = modifier
-            .padding(all = SizeConstants.ExtraSmallSize)
+            .padding(all = SizeConstants.ExtraTinySize)
             .animateContentSize()
             .bounceClick()
-            .clickable { onClick() }
+            .clickable { onClick() },
+        shape = RoundedCornerShape(SizeConstants.ExtraTinySize),
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .animateContentSize()
-                .padding(all = SizeConstants.LargeSize),
+                .padding(all = SizeConstants.ExtraTinySize),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Card(
@@ -80,7 +82,7 @@ fun StorageBreakdownItem(
                 }
             }
 
-            ExtraSmallHorizontalSpacer()
+            ExtraTinyHorizontalSpacer()
 
             Column {
                 Text(

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/components/StorageBreakdownItem.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/components/StorageBreakdownItem.kt
@@ -55,9 +55,7 @@ fun StorageBreakdownItem(
     )
     Card(
         modifier = modifier
-            .padding(all = SizeConstants.ExtraTinySize)
             .animateContentSize()
-            .bounceClick()
             .clickable { onClick() },
         shape = RoundedCornerShape(SizeConstants.ExtraTinySize),
     ) {
@@ -65,7 +63,7 @@ fun StorageBreakdownItem(
             modifier = Modifier
                 .fillMaxWidth()
                 .animateContentSize()
-                .padding(all = SizeConstants.ExtraTinySize),
+                .padding(all = SizeConstants.LargeSize),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Card(

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/components/DirectoryCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/components/DirectoryCard.kt
@@ -34,9 +34,7 @@ fun DirectoryCard(
 ) {
     Card(
         modifier = modifier
-            .padding(all = SizeConstants.ExtraTinySize)
-            .animateContentSize()
-            .bounceClick(),
+            .animateContentSize(),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer),
         shape = RoundedCornerShape(SizeConstants.ExtraTinySize),
         onClick = { onOpenDetails(item.type) }
@@ -45,7 +43,7 @@ fun DirectoryCard(
             modifier = Modifier
                 .fillMaxWidth()
                 .animateContentSize()
-                .padding(all = SizeConstants.ExtraTinySize),
+                .padding(all = SizeConstants.LargeSize),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Box(
@@ -56,6 +54,7 @@ fun DirectoryCard(
                 contentAlignment = Alignment.Center
             ) {
                 Icon(
+                    modifier = Modifier.bounceClick(),
                     painter = painterResource(id = item.icon),
                     contentDescription = null,
                     tint = Color.Unspecified

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/components/DirectoryCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/components/DirectoryCard.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.model.DirectoryItem
+import androidx.compose.foundation.shape.RoundedCornerShape
 
 @Composable
 fun DirectoryCard(
@@ -33,22 +34,23 @@ fun DirectoryCard(
 ) {
     Card(
         modifier = modifier
-            .padding(all = SizeConstants.ExtraSmallSize)
+            .padding(all = SizeConstants.ExtraTinySize)
             .animateContentSize()
             .bounceClick(),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer),
+        shape = RoundedCornerShape(SizeConstants.ExtraTinySize),
         onClick = { onOpenDetails(item.type) }
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .animateContentSize()
-                .padding(all = SizeConstants.LargeSize),
+                .padding(all = SizeConstants.ExtraTinySize),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Box(
                 modifier = Modifier
-                    .padding(end = 16.dp)
+                    .padding(end = SizeConstants.SmallSize)
                     .size(48.dp)
                     .background(MaterialTheme.colorScheme.primaryContainer, CircleShape),
                 contentAlignment = Alignment.Center

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/components/DirectoryGrid.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/components/DirectoryGrid.kt
@@ -1,52 +1,59 @@
 package com.d4rk.cleaner.app.clean.whatsapp.summary.ui.components
 
 import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.draw.clip
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.model.DirectoryItem
 
 @Composable
 fun DirectoryGrid(items: List<DirectoryItem>, onOpenDetails: (String) -> Unit) {
-    Card(
+    Box(
         modifier = Modifier
             .fillMaxWidth()
-            .animateContentSize()
-            .padding(horizontal = SizeConstants.MediumSize),
-        shape = RoundedCornerShape(SizeConstants.MediumSize),
-        colors = CardDefaults.cardColors(containerColor = Color.Transparent),
+            .padding(SizeConstants.MediumSize)
+            .animateContentSize(),
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(SizeConstants.ExtraTinySize)
+                .clip(RoundedCornerShape(SizeConstants.LargeIncreasedSize))
         ) {
-            items.chunked(2).forEach { chunk ->
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .animateContentSize(),
-                ) {
-                    for (item in chunk) {
-                        DirectoryCard(
-                            item = item,
-                            onOpenDetails = onOpenDetails,
-                            modifier = Modifier.weight(1f)
-                        )
-                    }
-                    if (chunk.size == 1) {
-                        androidx.compose.foundation.layout.Spacer(modifier = Modifier.weight(1f))
+            Column(verticalArrangement = Arrangement.spacedBy(SizeConstants.ExtraTinySize)) {
+                items.chunked(2).forEach { chunk ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .animateContentSize(),
+                        horizontalArrangement = Arrangement.spacedBy(
+                            space = SizeConstants.ExtraTinySize,
+                            alignment = Alignment.CenterHorizontally
+                        ),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        for (item in chunk) {
+                            DirectoryCard(
+                                item = item,
+                                onOpenDetails = onOpenDetails,
+                                modifier = Modifier.weight(1f)
+                            )
+                        }
+                        if (chunk.size == 1) {
+                            androidx.compose.foundation.layout.Spacer(modifier = Modifier.weight(1f))
+                        }
                     }
                 }
             }
         }
     }
 }
+

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/components/DirectoryGrid.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/components/DirectoryGrid.kt
@@ -5,34 +5,46 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.model.DirectoryItem
 
 @Composable
 fun DirectoryGrid(items: List<DirectoryItem>, onOpenDetails: (String) -> Unit) {
-    Column(
+    Card(
         modifier = Modifier
             .fillMaxWidth()
             .animateContentSize()
-            .padding(horizontal = SizeConstants.MediumSize)
+            .padding(horizontal = SizeConstants.MediumSize),
+        shape = RoundedCornerShape(SizeConstants.MediumSize),
+        colors = CardDefaults.cardColors(containerColor = Color.Transparent),
     ) {
-        items.chunked(2).forEach { chunk ->
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .animateContentSize()
-            ) {
-                for (item in chunk) {
-                    DirectoryCard(
-                        item = item,
-                        onOpenDetails = onOpenDetails,
-                        modifier = Modifier.weight(1f)
-                    )
-                }
-                if (chunk.size == 1) {
-                    androidx.compose.foundation.layout.Spacer(modifier = Modifier.weight(1f))
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(SizeConstants.ExtraTinySize)
+        ) {
+            items.chunked(2).forEach { chunk ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .animateContentSize(),
+                ) {
+                    for (item in chunk) {
+                        DirectoryCard(
+                            item = item,
+                            onOpenDetails = onOpenDetails,
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
+                    if (chunk.size == 1) {
+                        androidx.compose.foundation.layout.Spacer(modifier = Modifier.weight(1f))
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Wrap storage breakdown and WhatsApp grids in transparent, rounded cards
- Use extra tiny padding, radius and spacers for inner grid items
- Mirror the grouped card style in the memory manager shimmer

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689572a7cf28832d8ae9506bef3fa2c6