### PR TITLE
Avoid error styling on progress snackbars

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
@@ -332,7 +332,11 @@ class ScannerViewModel(
                 getWorkId = { dataStore.scannerCleanWorkId.first() },
                 saveWorkId = { dataStore.saveScannerCleanWorkId(it) },
                 clearWorkId = { dataStore.clearScannerCleanWorkId() },
-                showSnackbar = { postSnackbar(it.message, it.isError) },
+                showSnackbar = { snackbar ->
+                    if (snackbar.isError) {
+                        postSnackbar(snackbar.message, true)
+                    }
+                },
                 onEnqueued = { id ->
                     if (fromApkCleaner) _cleaningApks.value = true
                     _uiState.update { state ->

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/work/FileCleanupWorker.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/work/FileCleanupWorker.kt
@@ -289,7 +289,7 @@ class FileCleanupWorker(
         const val MAX_PATHS_PER_WORKER = 100
         private const val NOTIFICATION_ID = 2001
         private const val NOTIFICATION_CHANNEL = "file_cleanup"
-        private const val FINISH_DELAY_MS = 10000L
+        private const val FINISH_DELAY_MS = 2000L
         private const val TAG = "FileCleanupWorker"
     }
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/work/FileCleaner.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/work/FileCleaner.kt
@@ -35,11 +35,21 @@ object FileCleaner {
             )
         ) {
             FileCleanWorkEnqueuer.Result.AlreadyRunning -> {
-                showSnackbar(UiSnackbar(message = inProgressMessage))
+                showSnackbar(
+                    UiSnackbar(
+                        message = inProgressMessage,
+                        isError = false,
+                    ),
+                )
             }
             is FileCleanWorkEnqueuer.Result.Enqueued -> {
                 onEnqueued(result.id)
-                showSnackbar(UiSnackbar(message = inProgressMessage))
+                showSnackbar(
+                    UiSnackbar(
+                        message = inProgressMessage,
+                        isError = false,
+                    ),
+                )
             }
             is FileCleanWorkEnqueuer.Result.Error -> {
                 onError()


### PR DESCRIPTION
## Summary
- Ensure progress snackbars aren't marked as errors
- Hide "cleaning in progress" snackbar from analyze screen
- Shorten file cleanup worker completion delay

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895e5835420832d87cfadc462f28a89