### PR TITLE
Fix unnecessary select all dialog on deselect

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
@@ -467,7 +467,9 @@ class ScannerViewModel(
 
     private fun onGlobalSelectAllClick() {
         launch(context = dispatchers.io) {
-            val showDialog = dataStore.showGlobalSelectAllWarning.first()
+            // Only show the warning dialog when the user is selecting all items.
+            val isSelectingAll = _uiState.value.data?.analyzeState?.areAllFilesSelected != true
+            val showDialog = isSelectingAll && dataStore.showGlobalSelectAllWarning.first()
             if (showDialog) {
                 setGlobalSelectAllWarningDialogVisibility(true)
             } else {

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/WhatsAppDetailsScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/WhatsAppDetailsScreen.kt
@@ -311,7 +311,13 @@ fun DetailsScreen(
                                         sortedFiles.any { !it.isProtectedAndroidDir() },
                                 onClickSelectAll = {
                                     coroutineScope.launch {
-                                        if (dataStore.showGlobalSelectAllWarning.first()) {
+                                        val accessible = sortedFiles.filterNot { it.isProtectedAndroidDir() }
+                                        val allSelected =
+                                            selected.count { !it.isProtectedAndroidDir() } ==
+                                                accessible.size && accessible.isNotEmpty()
+                                        val showDialog =
+                                            !allSelected && dataStore.showGlobalSelectAllWarning.first()
+                                        if (showDialog) {
                                             showGlobalSelectAllWarning = true
                                         } else {
                                             toggleSelectAll()


### PR DESCRIPTION
## Summary
- Only show global select-all warning when user is selecting all files
- Avoid warning when deselecting all in WhatsApp details screen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68970d922d84832d95094df456681e6b