### PR TITLE
feat: show cleaning animation across cleaners

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/largefiles/domain/data/model/ui/UiLargeFilesModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/largefiles/domain/data/model/ui/UiLargeFilesModel.kt
@@ -1,5 +1,6 @@
 package com.d4rk.cleaner.app.clean.largefiles.domain.data.model.ui
 
+import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.CleaningState
 import java.io.File
 
 data class UiLargeFilesModel(
@@ -7,5 +8,6 @@ data class UiLargeFilesModel(
     val filesByDate: Map<String, List<File>> = emptyMap(),
     /** Map of file paths to selection state */
     val fileSelectionStates: Map<String, Boolean> = emptyMap(),
-    val selectedFileCount: Int = 0
+    val selectedFileCount: Int = 0,
+    val cleaningState: CleaningState = CleaningState.Idle,
 )

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/largefiles/ui/LargeFilesScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/largefiles/ui/LargeFilesScreen.kt
@@ -22,7 +22,9 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.ScreenStateHa
 import com.d4rk.android.libs.apptoolkit.core.ui.components.navigation.LargeTopAppBarWithScaffold
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.cleaner.R
+import com.d4rk.cleaner.app.clean.analyze.ui.components.CleaningAnimationScreen
 import com.d4rk.cleaner.app.clean.analyze.ui.components.FilesByDateSection
+import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.CleaningState
 import com.d4rk.cleaner.app.clean.largefiles.domain.actions.LargeFilesEvent
 import com.d4rk.cleaner.app.clean.largefiles.domain.data.model.ui.UiLargeFilesModel
 import org.koin.compose.viewmodel.koinViewModel
@@ -41,8 +43,12 @@ fun LargeFilesScreen(activity: LargeFilesActivity) {
         ScreenStateHandler(
             screenState = uiState,
             onLoading = {
-                LoadingScreen()
-                println("LoadingScreen")
+                if (uiState.data?.cleaningState == CleaningState.Cleaning) {
+                    CleaningAnimationScreen()
+                } else {
+                    LoadingScreen()
+                    println("LoadingScreen")
+                }
             },
             onEmpty = {
                 println("onEmpty")
@@ -56,7 +62,9 @@ fun LargeFilesScreen(activity: LargeFilesActivity) {
                         .fillMaxSize()
                 ) {
                     val (list, buttons) = createRefs()
-                    val enabled = data.selectedFileCount > 0
+                    val enabled = data.selectedFileCount > 0 &&
+                        data.cleaningState != CleaningState.Cleaning &&
+                        data.cleaningState != CleaningState.Error
                     FilesByDateSection(
                         modifier = Modifier.constrainAs(list) {
                             top.linkTo(parent.top)

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/trash/ui/TrashScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/trash/ui/TrashScreen.kt
@@ -23,6 +23,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.ScreenStateHa
 import com.d4rk.android.libs.apptoolkit.core.ui.components.navigation.LargeTopAppBarWithScaffold
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.cleaner.R
+import com.d4rk.cleaner.app.clean.analyze.ui.components.CleaningAnimationScreen
 import com.d4rk.cleaner.app.clean.analyze.ui.components.FilesByDateSection
 import com.d4rk.cleaner.app.clean.scanner.ui.components.TwoRowButtons
 import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.CleaningState
@@ -44,7 +45,11 @@ fun TrashScreen(activity: TrashActivity) {
         title = stringResource(id = R.string.trash),
         onBackClicked = { activity.finish() }) { paddingValues ->
         ScreenStateHandler(screenState = uiStateScreen, onLoading = {
-            LoadingScreen()
+            if (uiStateScreen.data?.cleaningState == CleaningState.Cleaning) {
+                CleaningAnimationScreen()
+            } else {
+                LoadingScreen()
+            }
         }, onEmpty = {
             NoDataScreen(
                 textMessage = R.string.trash_is_empty,

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsappCleanerSummaryScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsappCleanerSummaryScreen.kt
@@ -46,6 +46,8 @@ import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.model.UiWhatsAppCleane
 import com.d4rk.cleaner.app.clean.whatsapp.summary.ui.components.CleanerInfoCard
 import com.d4rk.cleaner.app.clean.whatsapp.summary.ui.components.DirectoryGrid
 import com.d4rk.cleaner.app.clean.whatsapp.summary.ui.components.WhatsAppEmptyState
+import com.d4rk.cleaner.app.clean.analyze.ui.components.CleaningAnimationScreen
+import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.CleaningState
 import com.d4rk.cleaner.app.clean.whatsapp.utils.constants.WhatsAppMediaConstants
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
@@ -91,7 +93,11 @@ fun WhatsappCleanerSummaryScreen(activity: Activity) {
         ScreenStateHandler(
             screenState = state,
             onLoading = {
-                LoadingScreen()
+                if (state.data?.cleaningState == CleaningState.Cleaning) {
+                    CleaningAnimationScreen()
+                } else {
+                    LoadingScreen()
+                }
             },
             onEmpty = {
                 WhatsAppEmptyState(paddingValues)


### PR DESCRIPTION
## Summary
- display cleaning animation while WhatsApp media is being cleaned
- add cleaning state handling to large files screen and viewmodel
- reuse cleaning animation for trash cleaner loading state

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897121644a0832d89403625c0878ca0