### PR TITLE
Refactor dashboard cards to share action layout

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/ui/components/ContactsCleanerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/ui/components/ContactsCleanerCard.kt
@@ -1,61 +1,23 @@
 package com.d4rk.cleaner.app.clean.contacts.ui.components
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Contacts
 import androidx.compose.material.icons.outlined.PersonSearch
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedCard
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.TonalIconButtonWithText
-import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.cleaner.R
+import com.d4rk.cleaner.app.clean.dashboard.ui.components.DashboardActionCard
 
 @Composable
 fun ContactsCleanerCard(modifier: Modifier = Modifier, onOpen: () -> Unit) {
-    OutlinedCard(
-        modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(SizeConstants.ExtraLargeSize)
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(SizeConstants.LargeSize),
-            verticalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize)
-        ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    imageVector = Icons.Outlined.Contacts,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary
-                )
-                Column(modifier = Modifier.padding(start = SizeConstants.MediumSize)) {
-                    Text(
-                        text = stringResource(id = R.string.contacts_cleaner_card_title),
-                        style = MaterialTheme.typography.titleMedium
-                    )
-                    Text(
-                        text = stringResource(id = R.string.contacts_cleaner_card_subtitle),
-                        style = MaterialTheme.typography.bodySmall
-                    )
-                }
-            }
-            TonalIconButtonWithText(
-                label = stringResource(id = R.string.open_contacts_cleaner),
-                icon = Icons.Outlined.PersonSearch,
-                onClick = onOpen,
-                modifier = Modifier.align(Alignment.End)
-            )
-        }
-    }
+    DashboardActionCard(
+        modifier = modifier,
+        icon = Icons.Outlined.Contacts,
+        title = stringResource(id = R.string.contacts_cleaner_card_title),
+        subtitle = stringResource(id = R.string.contacts_cleaner_card_subtitle),
+        actionLabel = stringResource(id = R.string.open_contacts_cleaner),
+        actionIcon = Icons.Outlined.PersonSearch,
+        onActionClick = onOpen
+    )
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/dashboard/ui/components/DashboardActionCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/dashboard/ui/components/DashboardActionCard.kt
@@ -1,0 +1,112 @@
+package com.d4rk.cleaner.app.clean.dashboard.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.constraintlayout.compose.ConstraintLayout
+import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.TonalIconButtonWithText
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+
+@Composable
+fun DashboardActionCard(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    actionLabel: String,
+    actionIcon: ImageVector? = null,
+    actionPainter: Painter? = null,
+    onActionClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    badgeText: String? = null,
+    actionEnabled: Boolean = true,
+    content: @Composable ColumnScope.() -> Unit = {},
+) {
+    OutlinedCard(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(SizeConstants.ExtraLargeSize),
+    ) {
+        Column {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(all = SizeConstants.LargeSize),
+                verticalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize)
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize)
+                ) {
+                    Icon(
+                        imageVector = icon,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = title,
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                        Text(
+                            text = subtitle,
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
+                }
+                content()
+            }
+
+            ConstraintLayout(
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                val (badge, action) = createRefs()
+
+                badgeText?.let { text ->
+                    Text(
+                        text = text,
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier
+                            .constrainAs(badge) {
+                                start.linkTo(parent.start)
+                                bottom.linkTo(parent.bottom)
+                            }
+                            .background(
+                                color = MaterialTheme.colorScheme.surfaceVariant,
+                                shape = RoundedCornerShape(topEnd = SizeConstants.ExtraLargeSize)
+                            )
+                            .padding(all = SizeConstants.MediumSize)
+                    )
+                }
+
+                TonalIconButtonWithText(
+                    label = actionLabel,
+                    icon = actionIcon,
+                    painter = actionPainter,
+                    onClick = onActionClick,
+                    enabled = actionEnabled,
+                    modifier = Modifier
+                        .constrainAs(action) {
+                            end.linkTo(parent.end, margin = SizeConstants.LargeSize)
+                            bottom.linkTo(parent.bottom, margin = SizeConstants.LargeSize)
+                        }
+                )
+            }
+        }
+    }
+}
+

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/ApkCleanerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/ApkCleanerCard.kt
@@ -6,20 +6,14 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Android
 import androidx.compose.material.icons.outlined.DeleteSweep
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.FilledTonalButton
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -28,11 +22,11 @@ import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.TonalIconButtonWithText
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.SmallVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.cleaner.R
 import com.d4rk.cleaner.app.apps.manager.domain.data.model.ApkInfo
+import com.d4rk.cleaner.app.clean.dashboard.ui.components.DashboardActionCard
 import com.d4rk.cleaner.app.clean.scanner.utils.helpers.FilePreviewHelper
 import com.d4rk.cleaner.core.utils.helpers.FileSizeFormatter
 import java.io.File
@@ -46,85 +40,52 @@ fun ApkCleanerCard(
 ) {
     val preview = apkFiles.take(4)
 
-    OutlinedCard(
-        modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(SizeConstants.ExtraLargeSize),
+    DashboardActionCard(
+        modifier = modifier,
+        icon = Icons.Outlined.Android,
+        title = stringResource(id = R.string.apk_card_title),
+        subtitle = stringResource(id = R.string.apk_card_subtitle),
+        actionLabel = stringResource(id = R.string.clean_apks),
+        actionIcon = Icons.Outlined.DeleteSweep,
+        onActionClick = { onCleanClick(apkFiles) },
+        actionEnabled = !isLoading
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(all = SizeConstants.LargeSize),
-            verticalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize)
-        ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    imageVector = Icons.Outlined.Android,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary
-                )
-                Column(modifier = Modifier.padding(start = SizeConstants.MediumSize)) {
-                    Text(
-                        text = stringResource(id = R.string.apk_card_title),
-                        style = MaterialTheme.typography.titleMedium
+        SmallVerticalSpacer()
+        AnimatedVisibility(visible = preview.isNotEmpty()) {
+            Row(
+                modifier = Modifier
+                    .horizontalScroll(rememberScrollState())
+                    .animateContentSize(),
+                horizontalArrangement = Arrangement.spacedBy(SizeConstants.SmallSize),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                preview.forEach { apk ->
+                    val apkFile = File(apk.path)
+                    ApkPreviewItem(
+                        file = apkFile,
+                        name = apkFile.name,
+                        size = FileSizeFormatter.format(apk.size)
                     )
-                    SmallVerticalSpacer()
+                }
+                if (apkFiles.size > preview.size) {
                     Text(
-                        text = stringResource(id = R.string.apk_card_subtitle),
+                        text = pluralStringResource(
+                            id = R.plurals.apk_card_more_format,
+                            count = apkFiles.size - preview.size,
+                            apkFiles.size - preview.size
+                        ),
                         style = MaterialTheme.typography.bodySmall
                     )
                 }
             }
-
-            SmallVerticalSpacer()
-
-            AnimatedVisibility(visible = preview.isNotEmpty()) {
-                Row(
-                    modifier = Modifier
-                        .horizontalScroll(rememberScrollState())
-                        .animateContentSize(),
-                    horizontalArrangement = Arrangement.spacedBy(SizeConstants.SmallSize),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    preview.forEach { apk ->
-                        val apkFile = File(apk.path)
-                        ApkPreviewItem(
-                            file = apkFile,
-                            name = apkFile.name,
-                            size = FileSizeFormatter.format(apk.size)
-                        )
-                    }
-                    if (apkFiles.size > preview.size) {
-                        Text(
-                            text = pluralStringResource(
-                                id = R.plurals.apk_card_more_format,
-                                count = apkFiles.size - preview.size,
-                                apkFiles.size - preview.size
-                            ),
-                            style = MaterialTheme.typography.bodySmall
-                        )
-                    }
-                }
-            }
-
-            if (isLoading) {
-                FilledTonalButton(
-                    onClick = { onCleanClick(apkFiles) },
-                    modifier = Modifier.align(Alignment.End),
-                    enabled = false,
-                ) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(SizeConstants.ButtonIconSize)
-                    )
-                }
-            } else {
-                TonalIconButtonWithText(
-                    modifier = Modifier.align(Alignment.End),
-                    onClick = { onCleanClick(apkFiles) },
-                    label = stringResource(id = R.string.clean_apks),
-                    icon = Icons.Outlined.DeleteSweep,
-                    enabled = true,
-                )
-            }
+        }
+        if (isLoading) {
+            CircularProgressIndicator(
+                modifier = Modifier
+                    .align(Alignment.End)
+                    .padding(top = SizeConstants.MediumSize)
+                    .size(SizeConstants.ButtonIconSize)
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/ApkCleanerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/ApkCleanerCard.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/CacheCleanerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/CacheCleanerCard.kt
@@ -1,100 +1,27 @@
 package com.d4rk.cleaner.app.clean.scanner.ui.components
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Cached
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedCard
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.constraintlayout.compose.ConstraintLayout
-import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.TonalIconButtonWithText
-import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.cleaner.R
+import com.d4rk.cleaner.app.clean.dashboard.ui.components.DashboardActionCard
 
 @Composable
 fun CacheCleanerCard(
     modifier: Modifier = Modifier,
     onScanClick: () -> Unit,
 ) {
-    OutlinedCard(
-        modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(SizeConstants.ExtraLargeSize),
-    ) {
-        Column {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(all = SizeConstants.LargeSize),
-                verticalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize)
-            ) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize)
-                ) {
-                    Icon(
-                        imageVector = Icons.Outlined.Cached,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.primary
-                    )
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = stringResource(id = R.string.cache_cleaner_card_title),
-                            style = MaterialTheme.typography.titleMedium
-                        )
-                        Text(
-                            text = stringResource(id = R.string.cache_cleaner_card_subtitle),
-                            style = MaterialTheme.typography.bodySmall
-                        )
-                    }
-                }
-            }
-
-            ConstraintLayout(
-                modifier = Modifier
-                    .fillMaxWidth()
-            ) {
-                val (wipText, actionButton) = createRefs()
-
-                Text(
-                    text = "W.I.P",
-                    style = MaterialTheme.typography.labelLarge,
-                    fontWeight = FontWeight.Bold,
-                    modifier = Modifier
-                        .constrainAs(wipText) {
-                            start.linkTo(parent.start)
-                            bottom.linkTo(parent.bottom)
-                        }
-                        .background(
-                            color = MaterialTheme.colorScheme.surfaceVariant,
-                            shape = RoundedCornerShape(topEnd = SizeConstants.ExtraLargeSize)
-                        )
-                        .padding(all = SizeConstants.MediumSize)
-                )
-
-                TonalIconButtonWithText(
-                    label = stringResource(id = R.string.scan_cache),
-                    painter = painterResource(id = R.drawable.ic_folder_search),
-                    onClick = onScanClick,
-                    modifier = Modifier
-                        .constrainAs(actionButton) {
-                            end.linkTo(parent.end, margin = SizeConstants.LargeSize)
-                            bottom.linkTo(parent.bottom, margin = SizeConstants.LargeSize)
-                        }
-                )
-            }
-        }
-    }
+    DashboardActionCard(
+        modifier = modifier,
+        icon = Icons.Outlined.Cached,
+        title = stringResource(id = R.string.cache_cleaner_card_title),
+        subtitle = stringResource(id = R.string.cache_cleaner_card_subtitle),
+        actionLabel = stringResource(id = R.string.scan_cache),
+        actionPainter = painterResource(id = R.drawable.ic_folder_search),
+        onActionClick = onScanClick,
+        badgeText = "W.I.P"
+    )
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/ClipboardCleanerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/ClipboardCleanerCard.kt
@@ -1,28 +1,19 @@
 package com.d4rk.cleaner.app.clean.scanner.ui.components
 
 import androidx.compose.animation.animateContentSize
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ContentPaste
 import androidx.compose.material.icons.outlined.ContentPasteOff
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
-import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.TonalIconButtonWithText
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.SmallVerticalSpacer
-import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.cleaner.R
+import com.d4rk.cleaner.app.clean.dashboard.ui.components.DashboardActionCard
 
 @Composable
 fun ClipboardCleanerCard(
@@ -30,55 +21,26 @@ fun ClipboardCleanerCard(
     modifier: Modifier = Modifier,
     onCleanClick: () -> Unit,
 ) {
-    OutlinedCard(
-        modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(SizeConstants.ExtraLargeSize),
+    DashboardActionCard(
+        modifier = modifier,
+        icon = Icons.Outlined.ContentPaste,
+        title = stringResource(id = R.string.clipboard_card_title),
+        subtitle = stringResource(id = R.string.clipboard_card_subtitle),
+        actionLabel = stringResource(id = R.string.clean_clipboard),
+        actionIcon = Icons.Outlined.ContentPasteOff,
+        onActionClick = onCleanClick
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(all = SizeConstants.LargeSize),
-            verticalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize)
-        ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    imageVector = Icons.Outlined.ContentPaste,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary
-                )
-                Column(modifier = Modifier.padding(start = SizeConstants.MediumSize)) {
-                    Text(
-                        text = stringResource(id = R.string.clipboard_card_title),
-                        style = MaterialTheme.typography.titleMedium
-                    )
-                    SmallVerticalSpacer()
-                    Text(
-                        text = stringResource(id = R.string.clipboard_card_subtitle),
-                        style = MaterialTheme.typography.bodySmall
-                    )
-                }
-            }
-
-            clipboardText?.let { text ->
-                Text(
-                    text = stringResource(id = R.string.clipboard_current_format, text),
-                    style = MaterialTheme.typography.bodyMedium,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.animateContentSize()
-                )
-            }
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.End,
-            ) {
-                TonalIconButtonWithText(
-                    label = stringResource(id = R.string.clean_clipboard),
-                    icon = Icons.Outlined.ContentPasteOff,
-                    onClick = onCleanClick,
-                )
-            }
+        clipboardText?.let { text ->
+            SmallVerticalSpacer()
+            Text(
+                text = stringResource(id = R.string.clipboard_current_format, text),
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .animateContentSize()
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/EmptyFolderCleanerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/EmptyFolderCleanerCard.kt
@@ -1,27 +1,17 @@
 package com.d4rk.cleaner.app.clean.scanner.ui.components
 
 import androidx.compose.animation.animateContentSize
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.DeleteSweep
 import androidx.compose.material.icons.outlined.Folder
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.TonalIconButtonWithText
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.SmallVerticalSpacer
-import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.cleaner.R
+import com.d4rk.cleaner.app.clean.dashboard.ui.components.DashboardActionCard
 import java.io.File
 
 @Composable
@@ -30,51 +20,20 @@ fun EmptyFolderCleanerCard(
     modifier: Modifier = Modifier,
     onCleanClick: (List<File>) -> Unit,
 ) {
-    OutlinedCard(
-        modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(SizeConstants.ExtraLargeSize),
+    DashboardActionCard(
+        modifier = modifier,
+        icon = Icons.Outlined.Folder,
+        title = stringResource(id = R.string.empty_folder_card_title),
+        subtitle = stringResource(id = R.string.empty_folder_card_subtitle),
+        actionLabel = stringResource(id = R.string.clean_empty_folders),
+        actionIcon = Icons.Outlined.DeleteSweep,
+        onActionClick = { onCleanClick(folders) }
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(all = SizeConstants.LargeSize),
-            verticalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize)
-        ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    imageVector = Icons.Outlined.Folder,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary
-                )
-                Column(modifier = Modifier.padding(start = SizeConstants.MediumSize)) {
-                    Text(
-                        text = stringResource(id = R.string.empty_folder_card_title),
-                        style = MaterialTheme.typography.titleMedium
-                    )
-                    SmallVerticalSpacer()
-                    Text(
-                        text = stringResource(id = R.string.empty_folder_card_subtitle),
-                        style = MaterialTheme.typography.bodySmall
-                    )
-                }
-            }
-
-            Text(
-                text = stringResource(id = R.string.empty_folders_found_format, folders.size),
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.animateContentSize()
-            )
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.End,
-            ) {
-                TonalIconButtonWithText(
-                    label = stringResource(id = R.string.clean_empty_folders),
-                    icon = Icons.Outlined.DeleteSweep,
-                    onClick = { onCleanClick(folders) },
-                )
-            }
-        }
+        SmallVerticalSpacer()
+        Text(
+            text = stringResource(id = R.string.empty_folders_found_format, folders.size),
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.animateContentSize()
+        )
     }
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/ImageOptimizerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/ImageOptimizerCard.kt
@@ -2,28 +2,19 @@ package com.d4rk.cleaner.app.clean.scanner.ui.components
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Image
 import androidx.compose.material.icons.outlined.ImageSearch
 import androidx.compose.material.icons.outlined.PhotoSizeSelectLarge
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.TonalIconButtonWithText
-import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.SmallVerticalSpacer
-import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.cleaner.R
+import com.d4rk.cleaner.app.clean.dashboard.ui.components.DashboardActionCard
 
 @Composable
 fun ImageOptimizerCard(
@@ -31,61 +22,29 @@ fun ImageOptimizerCard(
     lastOptimized: String? = null,
     onOptimizeClick: () -> Unit,
 ) {
-    OutlinedCard(
-        modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(SizeConstants.ExtraLargeSize),
+    DashboardActionCard(
+        modifier = modifier,
+        icon = Icons.Outlined.Image,
+        title = stringResource(id = R.string.image_optimizer_card_title),
+        subtitle = stringResource(id = R.string.image_optimizer_card_subtitle),
+        actionLabel = stringResource(id = R.string.optimize_image),
+        actionIcon = Icons.Outlined.ImageSearch,
+        onActionClick = onOptimizeClick
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(all = SizeConstants.LargeSize),
-            verticalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize),
-        ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize)
-            ) {
-                Icon(
-                    imageVector = Icons.Outlined.Image,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary
+        Icon(
+            imageVector = Icons.Outlined.PhotoSizeSelectLarge,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.align(Alignment.CenterHorizontally)
+        )
+        AnimatedVisibility(visible = lastOptimized != null) {
+            lastOptimized?.let { size ->
+                Text(
+                    text = stringResource(id = R.string.image_optimizer_last_format, size),
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.animateContentSize()
                 )
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = stringResource(id = R.string.image_optimizer_card_title),
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                    SmallVerticalSpacer()
-                    Text(
-                        text = stringResource(id = R.string.image_optimizer_card_subtitle),
-                        style = MaterialTheme.typography.bodySmall,
-                    )
-                }
             }
-
-            Icon(
-                imageVector = Icons.Outlined.PhotoSizeSelectLarge,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.align(Alignment.CenterHorizontally)
-            )
-
-            AnimatedVisibility(visible = lastOptimized != null) {
-                lastOptimized?.let { size ->
-                    Text(
-                        text = stringResource(id = R.string.image_optimizer_last_format, size),
-                        style = MaterialTheme.typography.bodySmall,
-                        modifier = Modifier.animateContentSize()
-                    )
-                }
-            }
-
-            TonalIconButtonWithText(
-                icon = Icons.Outlined.ImageSearch,
-                label = stringResource(id = R.string.optimize_image),
-                onClick = onOptimizeClick,
-                modifier = Modifier.align(Alignment.End),
-            )
         }
     }
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/LargeFilesCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/LargeFilesCard.kt
@@ -4,18 +4,12 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.DonutLarge
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -24,10 +18,10 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.TonalIconButtonWithText
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.SmallVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.cleaner.R
+import com.d4rk.cleaner.app.clean.dashboard.ui.components.DashboardActionCard
 import java.io.File
 
 @Composable
@@ -38,68 +32,41 @@ fun LargeFilesCard(
 ) {
     val preview = files.take(4)
 
-    OutlinedCard(
-        modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(SizeConstants.ExtraLargeSize),
+    DashboardActionCard(
+        modifier = modifier,
+        icon = Icons.Outlined.DonutLarge,
+        title = stringResource(id = R.string.large_files_card_title),
+        subtitle = stringResource(id = R.string.large_files_card_subtitle),
+        actionLabel = stringResource(id = R.string.open_large_files),
+        actionPainter = painterResource(id = R.drawable.ic_folder_search),
+        onActionClick = onOpenClick
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(all = SizeConstants.LargeSize),
-            verticalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize)
-        ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    imageVector = Icons.Outlined.DonutLarge,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary
-                )
-                Column(modifier = Modifier.padding(start = SizeConstants.MediumSize)) {
-                    Text(
-                        text = stringResource(id = R.string.large_files_card_title),
-                        style = MaterialTheme.typography.titleMedium
+        SmallVerticalSpacer()
+        AnimatedVisibility(visible = preview.isNotEmpty()) {
+            Row(
+                modifier = Modifier
+                    .horizontalScroll(rememberScrollState())
+                    .animateContentSize(),
+                horizontalArrangement = Arrangement.spacedBy(SizeConstants.SmallSize),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                preview.forEach { file ->
+                    FilePreviewCard(
+                        file = file,
+                        modifier = Modifier.size(64.dp)
                     )
-                    SmallVerticalSpacer()
+                }
+                if (files.size > preview.size) {
                     Text(
-                        text = stringResource(id = R.string.large_files_card_subtitle),
+                        text = pluralStringResource(
+                            id = R.plurals.large_files_card_more_format,
+                            count = files.size - preview.size,
+                            files.size - preview.size
+                        ),
                         style = MaterialTheme.typography.bodySmall
                     )
                 }
             }
-
-            AnimatedVisibility(visible = preview.isNotEmpty()) {
-                Row(
-                    modifier = Modifier
-                        .horizontalScroll(rememberScrollState())
-                        .animateContentSize(),
-                    horizontalArrangement = Arrangement.spacedBy(SizeConstants.SmallSize),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    preview.forEach { file ->
-                        FilePreviewCard(
-                            file = file,
-                            modifier = Modifier.size(64.dp)
-                        )
-                    }
-                    if (files.size > preview.size) {
-                        Text(
-                            text = pluralStringResource(
-                                id = R.plurals.large_files_card_more_format,
-                                count = files.size - preview.size,
-                                files.size - preview.size
-                            ),
-                            style = MaterialTheme.typography.bodySmall
-                        )
-                    }
-                }
-            }
-
-            TonalIconButtonWithText(
-                label = stringResource(id = R.string.open_large_files),
-                painter = painterResource(id = R.drawable.ic_folder_search),
-                onClick = onOpenClick,
-                modifier = Modifier.align(Alignment.End)
-            )
         }
     }
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/LinkCleanerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/LinkCleanerCard.kt
@@ -1,19 +1,11 @@
 package com.d4rk.cleaner.app.clean.scanner.ui.components
 
 import android.content.Intent
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ContentPaste
 import androidx.compose.material.icons.outlined.Link
 import androidx.compose.material.icons.outlined.LinkOff
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -22,16 +14,13 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.IconButton
-import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.TonalIconButtonWithText
-import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.SmallVerticalSpacer
-import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.cleaner.R
+import com.d4rk.cleaner.app.clean.dashboard.ui.components.DashboardActionCard
 import com.d4rk.cleaner.app.clean.link.ui.LinkCleanerActivity
 import com.d4rk.cleaner.core.utils.extensions.isValidUrl
 import kotlinx.coroutines.launch
@@ -41,80 +30,48 @@ fun LinkCleanerCard(
     modifier: Modifier = Modifier,
 ) {
     var linkText by rememberSaveable { mutableStateOf("") }
-    val clipboardManager = LocalClipboard.current // Use LocalClipboard
+    val clipboardManager = LocalClipboard.current
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
-    OutlinedCard(
-        modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(SizeConstants.ExtraLargeSize),
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(all = SizeConstants.LargeSize),
-            verticalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize)
-        ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    imageVector = Icons.Outlined.Link,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary
-                )
-                Column(modifier = Modifier.padding(start = SizeConstants.MediumSize)) {
-                    Text(
-                        text = stringResource(id = R.string.link_cleaner_card_title),
-                        style = MaterialTheme.typography.titleMedium
-                    )
-                    SmallVerticalSpacer()
-                    Text(
-                        text = stringResource(id = R.string.link_cleaner_card_subtitle),
-                        style = MaterialTheme.typography.bodySmall
-                    )
-                }
-            }
 
-            OutlinedTextField(
-                value = linkText,
-                onValueChange = { linkText = it },
-                label = { Text(text = stringResource(id = R.string.link)) },
-                singleLine = true,
-                trailingIcon = {
-                    IconButton(
-                        onClick = {
-                            scope.launch {
-                                val annotatedText = clipboardManager.nativeClipboard.primaryClip
-                                annotatedText?.toString()?.let {
-                                    val text = it.trim()
-                                    if (text.isNotEmpty()) {
-                                        linkText = text
-                                    }
+    DashboardActionCard(
+        modifier = modifier,
+        icon = Icons.Outlined.Link,
+        title = stringResource(id = R.string.link_cleaner_card_title),
+        subtitle = stringResource(id = R.string.link_cleaner_card_subtitle),
+        actionLabel = stringResource(id = R.string.clean_link),
+        actionIcon = Icons.Outlined.LinkOff,
+        onActionClick = {
+            val intent = Intent(context, LinkCleanerActivity::class.java).apply {
+                putExtra(Intent.EXTRA_TEXT, linkText)
+            }
+            context.startActivity(intent)
+        },
+        actionEnabled = linkText.isValidUrl()
+    ) {
+        OutlinedTextField(
+            value = linkText,
+            onValueChange = { linkText = it },
+            label = { Text(text = stringResource(id = R.string.link)) },
+            singleLine = true,
+            trailingIcon = {
+                IconButton(
+                    onClick = {
+                        scope.launch {
+                            val annotatedText = clipboardManager.nativeClipboard.primaryClip
+                            annotatedText?.toString()?.let {
+                                val text = it.trim()
+                                if (text.isNotEmpty()) {
+                                    linkText = text
                                 }
                             }
-                        },
-                        icon = Icons.Outlined.ContentPaste,
-                        iconContentDescription = stringResource(id = R.string.paste_from_clipboard)
-                    )
-
-                },
-                modifier = Modifier.fillMaxWidth()
-            )
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.End,
-            ) {
-                TonalIconButtonWithText(
-                    label = stringResource(id = R.string.clean_link),
-                    icon = Icons.Outlined.LinkOff,
-                    enabled = linkText.isValidUrl(),
-                    onClick = {
-                        val intent = Intent(context, LinkCleanerActivity::class.java).apply {
-                            putExtra(Intent.EXTRA_TEXT, linkText)
                         }
-                        context.startActivity(intent)
                     },
+                    icon = Icons.Outlined.ContentPaste,
+                    iconContentDescription = stringResource(id = R.string.paste_from_clipboard)
                 )
-            }
-        }
+            },
+            modifier = Modifier.fillMaxWidth()
+        )
     }
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/SystemStorageManagerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/SystemStorageManagerCard.kt
@@ -1,61 +1,23 @@
 package com.d4rk.cleaner.app.clean.scanner.ui.components
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.Launch
 import androidx.compose.material.icons.outlined.Storage
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedCard
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.TonalIconButtonWithText
-import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.cleaner.R
+import com.d4rk.cleaner.app.clean.dashboard.ui.components.DashboardActionCard
 
 @Composable
 fun SystemStorageManagerCard(modifier: Modifier = Modifier, onOpen: () -> Unit) {
-    OutlinedCard(
-        modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(SizeConstants.ExtraLargeSize),
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(SizeConstants.LargeSize),
-            verticalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize)
-        ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    imageVector = Icons.Outlined.Storage,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary
-                )
-                Column(modifier = Modifier.padding(start = SizeConstants.MediumSize)) {
-                    Text(
-                        text = stringResource(id = R.string.storage_manager_card_title),
-                        style = MaterialTheme.typography.titleMedium
-                    )
-                    Text(
-                        text = stringResource(id = R.string.storage_manager_card_subtitle),
-                        style = MaterialTheme.typography.bodySmall
-                    )
-                }
-            }
-            TonalIconButtonWithText(
-                label = stringResource(id = R.string.open_storage_manager),
-                icon = Icons.AutoMirrored.Outlined.Launch,
-                onClick = onOpen,
-                modifier = Modifier.align(Alignment.End)
-            )
-        }
-    }
+    DashboardActionCard(
+        modifier = modifier,
+        icon = Icons.Outlined.Storage,
+        title = stringResource(id = R.string.storage_manager_card_title),
+        subtitle = stringResource(id = R.string.storage_manager_card_subtitle),
+        actionLabel = stringResource(id = R.string.open_storage_manager),
+        actionIcon = Icons.AutoMirrored.Outlined.Launch,
+        onActionClick = onOpen
+    )
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/WhatsAppCleanerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/WhatsAppCleanerCard.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Whatsapp
 import androidx.compose.material.icons.outlined.Description
@@ -22,7 +21,6 @@ import androidx.compose.material.icons.outlined.Videocam
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -34,10 +32,10 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.TonalIconButtonWithText
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.SmallVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.cleaner.R
+import com.d4rk.cleaner.app.clean.dashboard.ui.components.DashboardActionCard
 import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.WhatsAppMediaSummary
 import java.io.File
 
@@ -47,62 +45,35 @@ fun WhatsAppCleanerCard(
     modifier: Modifier = Modifier,
     onCleanClick: () -> Unit
 ) {
-    OutlinedCard(
-        modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(SizeConstants.ExtraLargeSize),
+    DashboardActionCard(
+        modifier = modifier,
+        icon = Icons.Filled.Whatsapp,
+        title = stringResource(id = R.string.whatsapp_card_title),
+        subtitle = stringResource(id = R.string.whatsapp_card_subtitle),
+        actionLabel = stringResource(id = R.string.clean_whatsapp),
+        actionPainter = painterResource(id = R.drawable.ic_folder_search),
+        onActionClick = onCleanClick
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(all = SizeConstants.LargeSize),
-            verticalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize)
-        ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    imageVector = Icons.Default.Whatsapp,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary
-                )
-                Column(modifier = Modifier.padding(start = SizeConstants.MediumSize)) {
-                    Text(
-                        text = stringResource(id = R.string.whatsapp_card_title),
-                        style = MaterialTheme.typography.titleMedium
-                    )
-                    SmallVerticalSpacer()
-                    Text(
-                        text = stringResource(id = R.string.whatsapp_card_subtitle),
-                        style = MaterialTheme.typography.bodySmall
-                    )
-                }
-            }
-
-            AnimatedVisibility(visible = mediaSummary.images.isNotEmpty()) {
-                CategoryRow(
-                    icon = Icons.Outlined.Image,
-                    label = stringResource(id = R.string.images),
-                    files = mediaSummary.images
-                )
-            }
-            AnimatedVisibility(visible = mediaSummary.videos.isNotEmpty()) {
-                CategoryRow(
-                    icon = Icons.Outlined.Videocam,
-                    label = stringResource(id = R.string.videos),
-                    files = mediaSummary.videos
-                )
-            }
-            AnimatedVisibility(visible = mediaSummary.documents.isNotEmpty()) {
-                CategoryRow(
-                    icon = Icons.Outlined.Description,
-                    label = stringResource(id = R.string.documents),
-                    files = mediaSummary.documents
-                )
-            }
-
-            TonalIconButtonWithText(
-                label = stringResource(id = R.string.clean_whatsapp),
-                painter = painterResource(id = R.drawable.ic_folder_search),
-                onClick = onCleanClick,
-                modifier = Modifier.align(Alignment.End),
+        SmallVerticalSpacer()
+        AnimatedVisibility(visible = mediaSummary.images.isNotEmpty()) {
+            CategoryRow(
+                icon = Icons.Outlined.Image,
+                label = stringResource(id = R.string.images),
+                files = mediaSummary.images
+            )
+        }
+        AnimatedVisibility(visible = mediaSummary.videos.isNotEmpty()) {
+            CategoryRow(
+                icon = Icons.Outlined.Videocam,
+                label = stringResource(id = R.string.videos),
+                files = mediaSummary.videos
+            )
+        }
+        AnimatedVisibility(visible = mediaSummary.documents.isNotEmpty()) {
+            CategoryRow(
+                icon = Icons.Outlined.Description,
+                label = stringResource(id = R.string.documents),
+                files = mediaSummary.documents
             )
         }
     }


### PR DESCRIPTION
## Summary
- add reusable `DashboardActionCard` composable with optional badge and action button
- refactor cleaner dashboard cards to use the new base component
- centralize action slots for consistent previews and buttons

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897322f22ec832daa25e3ef578b6b51