### PR TITLE
Make dashboard card headers navigable

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/ui/components/ContactsCleanerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/ui/components/ContactsCleanerCard.kt
@@ -18,6 +18,7 @@ fun ContactsCleanerCard(modifier: Modifier = Modifier, onOpen: () -> Unit) {
         subtitle = stringResource(id = R.string.contacts_cleaner_card_subtitle),
         actionLabel = stringResource(id = R.string.open_contacts_cleaner),
         actionIcon = Icons.Outlined.PersonSearch,
-        onActionClick = onOpen
+        onActionClick = onOpen,
+        onHeaderClick = onOpen
     )
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/dashboard/ui/components/DashboardActionCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/dashboard/ui/components/DashboardActionCard.kt
@@ -1,6 +1,7 @@
 package com.d4rk.cleaner.app.clean.dashboard.ui.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -34,6 +35,8 @@ fun DashboardActionCard(
     modifier: Modifier = Modifier,
     badgeText: String? = null,
     actionEnabled: Boolean = true,
+    onHeaderClick: (() -> Unit)? = null,
+    headerEnabled: Boolean = actionEnabled,
     content: @Composable ColumnScope.() -> Unit = {},
 ) {
     OutlinedCard(
@@ -48,6 +51,9 @@ fun DashboardActionCard(
                 verticalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize)
             ) {
                 Row(
+                    modifier = onHeaderClick?.let {
+                        Modifier.clickable(enabled = headerEnabled, onClick = it)
+                    } ?: Modifier,
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize)
                 ) {

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/CacheCleanerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/CacheCleanerCard.kt
@@ -22,6 +22,7 @@ fun CacheCleanerCard(
         actionLabel = stringResource(id = R.string.scan_cache),
         actionPainter = painterResource(id = R.drawable.ic_folder_search),
         onActionClick = onScanClick,
+        onHeaderClick = onScanClick,
         badgeText = "W.I.P"
     )
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/EmptyFolderCleanerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/EmptyFolderCleanerCard.kt
@@ -27,7 +27,8 @@ fun EmptyFolderCleanerCard(
         subtitle = stringResource(id = R.string.empty_folder_card_subtitle),
         actionLabel = stringResource(id = R.string.clean_empty_folders),
         actionIcon = Icons.Outlined.DeleteSweep,
-        onActionClick = { onCleanClick(folders) }
+        onActionClick = { onCleanClick(folders) },
+        onHeaderClick = { onCleanClick(folders) }
     ) {
         SmallVerticalSpacer()
         Text(

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/ImageOptimizerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/ImageOptimizerCard.kt
@@ -29,7 +29,8 @@ fun ImageOptimizerCard(
         subtitle = stringResource(id = R.string.image_optimizer_card_subtitle),
         actionLabel = stringResource(id = R.string.optimize_image),
         actionIcon = Icons.Outlined.ImageSearch,
-        onActionClick = onOptimizeClick
+        onActionClick = onOptimizeClick,
+        onHeaderClick = onOptimizeClick
     ) {
         Icon(
             imageVector = Icons.Outlined.PhotoSizeSelectLarge,

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/LargeFilesCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/LargeFilesCard.kt
@@ -39,7 +39,8 @@ fun LargeFilesCard(
         subtitle = stringResource(id = R.string.large_files_card_subtitle),
         actionLabel = stringResource(id = R.string.open_large_files),
         actionPainter = painterResource(id = R.drawable.ic_folder_search),
-        onActionClick = onOpenClick
+        onActionClick = onOpenClick,
+        onHeaderClick = onOpenClick
     ) {
         SmallVerticalSpacer()
         AnimatedVisibility(visible = preview.isNotEmpty()) {

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/LinkCleanerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/LinkCleanerCard.kt
@@ -34,6 +34,13 @@ fun LinkCleanerCard(
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
 
+    val openLinkCleaner = {
+        val intent = Intent(context, LinkCleanerActivity::class.java).apply {
+            putExtra(Intent.EXTRA_TEXT, linkText)
+        }
+        context.startActivity(intent)
+    }
+
     DashboardActionCard(
         modifier = modifier,
         icon = Icons.Outlined.Link,
@@ -41,13 +48,9 @@ fun LinkCleanerCard(
         subtitle = stringResource(id = R.string.link_cleaner_card_subtitle),
         actionLabel = stringResource(id = R.string.clean_link),
         actionIcon = Icons.Outlined.LinkOff,
-        onActionClick = {
-            val intent = Intent(context, LinkCleanerActivity::class.java).apply {
-                putExtra(Intent.EXTRA_TEXT, linkText)
-            }
-            context.startActivity(intent)
-        },
-        actionEnabled = linkText.isValidUrl()
+        onActionClick = openLinkCleaner,
+        actionEnabled = linkText.isValidUrl(),
+        onHeaderClick = openLinkCleaner
     ) {
         OutlinedTextField(
             value = linkText,

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/SystemStorageManagerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/SystemStorageManagerCard.kt
@@ -18,6 +18,7 @@ fun SystemStorageManagerCard(modifier: Modifier = Modifier, onOpen: () -> Unit) 
         subtitle = stringResource(id = R.string.storage_manager_card_subtitle),
         actionLabel = stringResource(id = R.string.open_storage_manager),
         actionIcon = Icons.AutoMirrored.Outlined.Launch,
-        onActionClick = onOpen
+        onActionClick = onOpen,
+        onHeaderClick = onOpen
     )
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/WhatsAppCleanerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/WhatsAppCleanerCard.kt
@@ -52,7 +52,8 @@ fun WhatsAppCleanerCard(
         subtitle = stringResource(id = R.string.whatsapp_card_subtitle),
         actionLabel = stringResource(id = R.string.clean_whatsapp),
         actionPainter = painterResource(id = R.drawable.ic_folder_search),
-        onActionClick = onCleanClick
+        onActionClick = onCleanClick,
+        onHeaderClick = onCleanClick
     ) {
         SmallVerticalSpacer()
         AnimatedVisibility(visible = mediaSummary.images.isNotEmpty()) {


### PR DESCRIPTION
## Summary
- Allow `DashboardActionCard` headers to receive click events
- Open WhatsApp, large files, and other cleaners when tapping card headers

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68978b51319c832da4344422a0236ac3