### PR TITLE
Switch tab when selecting analyze category

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/components/tabs/TabsContent.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/components/tabs/TabsContent.kt
@@ -106,7 +106,11 @@ fun TabsContent(
                                 state = toggleState,
                                 onClick = {
                                     if (hasFiles) {
+                                        view.playSoundEffect(SoundEffectConstants.CLICK)
                                         viewModel.toggleSelectFilesForCategory(category = title)
+                                        coroutineScope.launch {
+                                            pagerState.animateScrollToPage(page = index)
+                                        }
                                     }
                                 },
                                 enabled = hasFiles


### PR DESCRIPTION
## Summary
- Switch analyze screen tab when user selects a category checkbox

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897b2df6fa8832d8017035518dc5f5a