### PR TITLE
Implement dynamic AdMob slots on home screen

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/Cleaner.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/Cleaner.kt
@@ -33,6 +33,10 @@ import org.koin.android.ext.android.getKoin
 class Cleaner : BaseCoreManager(), SingletonImageLoader.Factory, DefaultLifecycleObserver {
     private var currentActivity: Activity? = null
 
+    companion object {
+        var sessionStartTime: Long = System.currentTimeMillis()
+    }
+
     private val adsCoreManager: AdsCoreManager by lazy { getKoin().get<AdsCoreManager>() }
 
     override fun onCreate() {
@@ -40,6 +44,7 @@ class Cleaner : BaseCoreManager(), SingletonImageLoader.Factory, DefaultLifecycl
         StreakTracker.initialize()
         SingletonImageLoader.setSafe { newImageLoader(this) }
         super<BaseCoreManager>.onCreate()
+        sessionStartTime = System.currentTimeMillis()
         CleanupReminderScheduler.schedule(this)
         StreakReminderScheduler.schedule(this)
         runBlocking {


### PR DESCRIPTION
## Summary
- Track session start time for adaptive ad capping
- Dynamically insert AdMob banners around home cards with spacing rules

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_6897cc4313b0832d8dcf3d97761877a6