### PR TITLE
Filter empty analyze categories to hide unused tabs

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/AnalyzeScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/AnalyzeScreen.kt
@@ -46,7 +46,8 @@ fun AnalyzeScreen(
 ) {
     val coroutineScope: CoroutineScope = rememberCoroutineScope()
     val hasSelectedFiles: Boolean = data.analyzeState.selectedFilesCount > 0
-    val groupedFiles: Map<String, List<FileEntry>> = data.analyzeState.groupedFiles
+    val groupedFiles: Map<String, List<FileEntry>> =
+        data.analyzeState.groupedFiles.filterValues { it.isNotEmpty() }
     val showActions: Boolean =
         data.analyzeState.state == CleaningState.ReadyToClean && hasSelectedFiles
 

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/domain/operations/FileAnalyzer.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/domain/operations/FileAnalyzer.kt
@@ -86,13 +86,13 @@ class FileAnalyzer(
         }
 
         val emptyFoldersTitle = baseFinalTitles[8]
-        if (preferences[ExtensionsConstants.EMPTY_FOLDERS] == true) {
-            filesMap[emptyFoldersTitle] = emptyFolders.map { FileEntry(it.absolutePath, 0, it.lastModified()) }.toMutableList()
+        if (preferences[ExtensionsConstants.EMPTY_FOLDERS] == true && emptyFolders.isNotEmpty()) {
+            filesMap[emptyFoldersTitle] = emptyFolders
+                .map { FileEntry(it.absolutePath, 0, it.lastModified()) }
+                .toMutableList()
         }
 
-        val filteredMap = filesMap.filter { (key, value) ->
-            value.isNotEmpty() || (key == emptyFoldersTitle && preferences[ExtensionsConstants.EMPTY_FOLDERS] == true)
-        }
+        val filteredMap = filesMap.filterValues { it.isNotEmpty() }
 
         return Triple(filteredMap, duplicateOriginals, duplicateGroups)
     }


### PR DESCRIPTION
## Summary
- Only add the empty-folder category when folders exist
- Drop categories with no files and pass the filtered list to the Analyze UI

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898de1e22ac832d89c57b89678f97e4