### PR TITLE
Reload WhatsApp details after cleaning

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/WhatsAppDetailsScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/WhatsAppDetailsScreen.kt
@@ -162,7 +162,10 @@ fun DetailsScreen(
         ScreenStateHandler(
             screenState = state,
             onLoading = {
-                if (state.data?.cleaningState == CleaningState.Cleaning) {
+                if (
+                    state.data?.cleaningState == CleaningState.Cleaning ||
+                    state.data?.cleaningState == CleaningState.Result
+                ) {
                     CleaningAnimationScreen()
                 } else {
                     LoadingScreen()

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/WhatsAppDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/WhatsAppDetailsViewModel.kt
@@ -11,6 +11,7 @@ import com.d4rk.cleaner.app.clean.whatsapp.details.domain.actions.WhatsAppDetail
 import com.d4rk.cleaner.app.clean.whatsapp.details.domain.model.UiWhatsAppDetailsModel
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.usecases.GetWhatsAppMediaFilesUseCase
 import com.d4rk.cleaner.core.data.datastore.DataStore
+import com.d4rk.cleaner.core.utils.helpers.CleaningEventBus
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import java.io.File
@@ -28,11 +29,20 @@ class DetailsViewModel(
     initialState = UiStateScreen(data = UiWhatsAppDetailsModel())
 ) {
 
+    private var currentType: String = ""
+
     init {
         launch {
             dataStore.whatsappGridView.collectLatest { isGrid ->
                 _uiState.updateData(newState = _uiState.value.screenState) { current ->
                     current.copy(isGridView = isGrid)
+                }
+            }
+        }
+        launch(dispatchers.io) {
+            CleaningEventBus.events.collectLatest { success ->
+                if (success && currentType.isNotEmpty()) {
+                    onEvent(WhatsAppDetailsEvent.LoadFiles(currentType))
                 }
             }
         }
@@ -52,6 +62,7 @@ class DetailsViewModel(
     }
 
     private fun loadFiles(type: String, page: Int) {
+        currentType = type
         launch(dispatchers.io) {
             getFilesUseCase(type, page * PAGE_SIZE, PAGE_SIZE).collectLatest { result ->
                 when (result) {


### PR DESCRIPTION
## Summary
- Refresh WhatsApp details when cleaning jobs complete by listening to `CleaningEventBus`
- Preserve last media type and reload files upon successful cleaning
- Display cleaning animation during cleanup results in WhatsApp details

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898fc0dc5b8832da5260a6024a6b615