### PR TITLE
Show result state before reloading trash items

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/trash/ui/TrashViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/trash/ui/TrashViewModel.kt
@@ -110,7 +110,15 @@ class TrashViewModel(
                     }
                 }
 
+                _uiState.updateData(newState = _uiState.value.screenState) {
+                    it.copy(cleaningState = CleaningState.Result)
+                }
+
                 onEvent(TrashEvent.LoadTrashItems)
+
+                _uiState.updateData(newState = _uiState.value.screenState) {
+                    it.copy(cleaningState = CleaningState.Idle)
+                }
 
                 val message = if (failedCount > 0) {
                     UiTextHelper.StringResource(
@@ -119,10 +127,6 @@ class TrashViewModel(
                     )
                 } else {
                     UiTextHelper.StringResource(R.string.all_clean)
-                }
-
-                _uiState.updateData(newState = _uiState.value.screenState) {
-                    it.copy(cleaningState = CleaningState.Idle)
                 }
 
                 sendAction(


### PR DESCRIPTION
## Summary
- show cleaning result before refreshing trash list
- revert cleaning state to idle after reload

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68990166edbc832da51ee72d67a68cb4