### PR TITLE
Use plurals for current streak label

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/WeeklyCleanStreakCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/WeeklyCleanStreakCard.kt
@@ -126,7 +126,11 @@ fun WeeklyCleanStreakCard(
             }
 
             Text(
-                text = stringResource(id = R.string.current_streak_label, streakDays),
+                text = pluralStringResource(
+                    id = R.plurals.current_streak_label,
+                    count = streakDays,
+                    streakDays
+                ),
                 style = MaterialTheme.typography.bodyMedium
             )
             Text(

--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -437,6 +437,13 @@
     <string name="cleanup_failed_details">تعذر حذف بعض الملفات</string>
     <string name="cleanup_cancelled">تم إلغاء التنظيف</string>
     <string name="cleanup_partial">تم حذف %1$d ملفًا، فشل حذف %2$d</string>
-    <string name="current_streak_label">السلسلة الحالية: %1$d يومًا على التوالي</string>
+    <plurals name="current_streak_label">
+        <item quantity="zero">السلسلة الحالية: %1$d يومًا على التوالي</item>
+        <item quantity="one">السلسلة الحالية: %1$d يومًا على التوالي</item>
+        <item quantity="two">السلسلة الحالية: %1$d يومًا على التوالي</item>
+        <item quantity="few">السلسلة الحالية: %1$d يومًا على التوالي</item>
+        <item quantity="many">السلسلة الحالية: %1$d يومًا على التوالي</item>
+        <item quantity="other">السلسلة الحالية: %1$d يومًا على التوالي</item>
+    </plurals>
     <string name="longest_streak_label">أطول سلسلة: رقم قياسي %1$d يومًا!</string>
 </resources>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -404,6 +404,9 @@
     <string name="cleanup_failed_details">Някои файлове не можаха да бъдат изтрити</string>
     <string name="cleanup_cancelled">Почистването е отменено</string>
     <string name="cleanup_partial">%1$d файла изтрити, %2$d неуспешни</string>
-    <string name="current_streak_label">Текуща серия: %1$d дни подред</string>
+    <plurals name="current_streak_label">
+        <item quantity="one">Текуща серия: %1$d ден подред</item>
+        <item quantity="other">Текуща серия: %1$d дни подред</item>
+    </plurals>
     <string name="longest_streak_label">Най-дълга серия: рекорд от %1$d дни!</string>
 </resources>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -404,6 +404,9 @@
     <string name="cleanup_failed_details">কিছু ফাইল মুছে ফেলা যায়নি</string>
     <string name="cleanup_cancelled">পরিষ্কার বাতিল করা হয়েছে</string>
     <string name="cleanup_partial">%1$d টি ফাইল মুছে ফেলা হয়েছে, %2$d টি ব্যর্থ হয়েছে</string>
-    <string name="current_streak_label">বর্তমান স্ট্রীক: পরপর %1$d দিন</string>
+    <plurals name="current_streak_label">
+        <item quantity="one">বর্তমান স্ট্রীক: পরপর %1$d দিন</item>
+        <item quantity="other">বর্তমান স্ট্রীক: পরপর %1$d দিন</item>
+    </plurals>
     <string name="longest_streak_label">দীর্ঘতম স্ট্রীক: %1$d দিনের রেকর্ড!</string>
 </resources>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -405,6 +405,9 @@
     <string name="cleanup_failed_details">Einige Dateien konnten nicht gelöscht werden</string>
     <string name="cleanup_cancelled">Bereinigung abgebrochen</string>
     <string name="cleanup_partial">%1$d Dateien gelöscht, %2$d fehlgeschlagen</string>
-    <string name="current_streak_label">Aktuelle Serie: %1$d Tage infolge</string>
+    <plurals name="current_streak_label">
+        <item quantity="one">Aktuelle Serie: %1$d Tag infolge</item>
+        <item quantity="other">Aktuelle Serie: %1$d Tage infolge</item>
+    </plurals>
     <string name="longest_streak_label">Längste Serie: Rekord von %1$d Tagen!</string>
 </resources>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -413,6 +413,10 @@
     <string name="cleanup_failed_details">No se pudieron eliminar algunos archivos</string>
     <string name="cleanup_cancelled">Limpieza cancelada</string>
     <string name="cleanup_partial">%1$d archivos eliminados, %2$d fallidos</string>
-    <string name="current_streak_label">Racha actual: %1$d días seguidos</string>
+    <plurals name="current_streak_label">
+        <item quantity="one">Racha actual: %1$d día seguido</item>
+        <item quantity="many">Racha actual: %1$d días seguidos</item>
+        <item quantity="other">Racha actual: %1$d días seguidos</item>
+    </plurals>
     <string name="longest_streak_label">Racha más larga: ¡récord de %1$d días!</string>
 </resources>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -413,6 +413,10 @@
     <string name="cleanup_failed_details">No se pudieron eliminar algunos archivos</string>
     <string name="cleanup_cancelled">Limpieza cancelada</string>
     <string name="cleanup_partial">%1$d archivos eliminados, %2$d fallidos</string>
-    <string name="current_streak_label">Racha actual: %1$d días seguidos</string>
+    <plurals name="current_streak_label">
+        <item quantity="one">Racha actual: %1$d día seguido</item>
+        <item quantity="many">Racha actual: %1$d días seguidos</item>
+        <item quantity="other">Racha actual: %1$d días seguidos</item>
+    </plurals>
     <string name="longest_streak_label">Racha más larga: ¡récord de %1$d días!</string>
 </resources>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -405,6 +405,9 @@
     <string name="cleanup_failed_details">May ilang file na hindi matanggal</string>
     <string name="cleanup_cancelled">Kinansela ang paglilinis</string>
     <string name="cleanup_partial">Na-delete ang %1$d na file, nabigo ang %2$d</string>
-    <string name="current_streak_label">Kasalukuyang streak: %1$d araw nang sunod-sunod</string>
+    <plurals name="current_streak_label">
+        <item quantity="one">Kasalukuyang streak: %1$d araw nang sunod-sunod</item>
+        <item quantity="other">Kasalukuyang streak: %1$d araw nang sunod-sunod</item>
+    </plurals>
     <string name="longest_streak_label">Pinakamahabang streak: rekord na %1$d araw!</string>
 </resources>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -414,6 +414,10 @@
     <string name="cleanup_failed_details">Certains fichiers n\'ont pas pu être supprimés</string>
     <string name="cleanup_cancelled">Nettoyage annulé</string>
     <string name="cleanup_partial">%1$d fichiers supprimés, %2$d échoués</string>
-    <string name="current_streak_label">Série actuelle : %1$d jours d\'affilée</string>
+    <plurals name="current_streak_label">
+        <item quantity="one">Série actuelle : %1$d jour d\'affilée</item>
+        <item quantity="many">Série actuelle : %1$d jours d\'affilée</item>
+        <item quantity="other">Série actuelle : %1$d jours d\'affilée</item>
+    </plurals>
     <string name="longest_streak_label">Série la plus longue : record de %1$d jours !</string>
 </resources>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -405,6 +405,9 @@
     <string name="cleanup_failed_details">कुछ फ़ाइलें हटाई नहीं जा सकीं</string>
     <string name="cleanup_cancelled">सफाई रद्द की गई</string>
     <string name="cleanup_partial">%1$d फ़ाइलें हटाई गईं, %2$d असफल रहीं</string>
-    <string name="current_streak_label">वर्तमान स्ट्रीक: लगातार %1$d दिन</string>
+    <plurals name="current_streak_label">
+        <item quantity="one">वर्तमान स्ट्रीक: लगातार %1$d दिन</item>
+        <item quantity="other">वर्तमान स्ट्रीक: लगातार %1$d दिन</item>
+    </plurals>
     <string name="longest_streak_label">सबसे लंबी स्ट्रीक: %1$d दिनों का रिकॉर्ड!</string>
 </resources>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -405,6 +405,9 @@
     <string name="cleanup_failed_details">Néhány fájlt nem sikerült törölni</string>
     <string name="cleanup_cancelled">Tisztítás megszakítva</string>
     <string name="cleanup_partial">%1$d fájl törölve, %2$d sikertelen</string>
-    <string name="current_streak_label">Jelenlegi sorozat: %1$d nap egymás után</string>
+    <plurals name="current_streak_label">
+        <item quantity="one">Jelenlegi sorozat: %1$d nap egymás után</item>
+        <item quantity="other">Jelenlegi sorozat: %1$d nap egymás után</item>
+    </plurals>
     <string name="longest_streak_label">Leghosszabb sorozat: %1$d napos rekord!</string>
 </resources>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -397,6 +397,8 @@
     <string name="cleanup_failed_details">Beberapa file tidak dapat dihapus</string>
     <string name="cleanup_cancelled">Pembersihan dibatalkan</string>
     <string name="cleanup_partial">%1$d file dihapus, %2$d gagal</string>
-    <string name="current_streak_label">Streak saat ini: %1$d hari berturut-turut</string>
+    <plurals name="current_streak_label">
+        <item quantity="other">Streak saat ini: %1$d hari berturut-turut</item>
+    </plurals>
     <string name="longest_streak_label">Streak terpanjang: rekor %1$d hari!</string>
 </resources>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -413,6 +413,10 @@
     <string name="cleanup_failed_details">Impossibile eliminare alcuni file</string>
     <string name="cleanup_cancelled">Pulizia annullata</string>
     <string name="cleanup_partial">%1$d file eliminati, %2$d non riusciti</string>
-    <string name="current_streak_label">Serie attuale: %1$d giorni di fila</string>
+    <plurals name="current_streak_label">
+        <item quantity="one">Serie attuale: %1$d giorno di fila</item>
+        <item quantity="many">Serie attuale: %1$d giorni di fila</item>
+        <item quantity="other">Serie attuale: %1$d giorni di fila</item>
+    </plurals>
     <string name="longest_streak_label">Serie più lunga: record di %1$d giorni!</string>
 </resources>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -397,6 +397,8 @@
     <string name="cleanup_failed_details">一部のファイルを削除できませんでした</string>
     <string name="cleanup_cancelled">クリーンアップをキャンセルしました</string>
     <string name="cleanup_partial">%1$d 件のファイルを削除、%2$d 件が失敗しました</string>
-    <string name="current_streak_label">現在の連続記録：%1$d日連続</string>
+    <plurals name="current_streak_label">
+        <item quantity="other">現在の連続記録：%1$d日連続</item>
+    </plurals>
     <string name="longest_streak_label">最長記録：%1$d日間の記録！</string>
 </resources>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -397,6 +397,8 @@
     <string name="cleanup_failed_details">일부 파일을 삭제할 수 없습니다</string>
     <string name="cleanup_cancelled">정리가 취소되었습니다</string>
     <string name="cleanup_partial">%1$d개의 파일 삭제, %2$d개 실패</string>
-    <string name="current_streak_label">현재 스트릭: %1$d일 연속</string>
+    <plurals name="current_streak_label">
+        <item quantity="other">현재 스트릭: %1$d일 연속</item>
+    </plurals>
     <string name="longest_streak_label">가장 긴 스트릭: %1$d일 기록!</string>
 </resources>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -421,6 +421,11 @@
     <string name="cleanup_failed_details">Niektórych plików nie można było usunąć</string>
     <string name="cleanup_cancelled">Czyszczenie anulowane</string>
     <string name="cleanup_partial">%1$d plików usunięto, %2$d nie powiodło się</string>
-    <string name="current_streak_label">Obecna passa: %1$d dni z rzędu</string>
+    <plurals name="current_streak_label">
+        <item quantity="one">Obecna passa: %1$d dzień z rzędu</item>
+        <item quantity="few">Obecna passa: %1$d dni z rzędu</item>
+        <item quantity="many">Obecna passa: %1$d dni z rzędu</item>
+        <item quantity="other">Obecna passa: %1$d dni z rzędu</item>
+    </plurals>
     <string name="longest_streak_label">Najdłuższa passa: rekord %1$d dni!</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -413,6 +413,10 @@
     <string name="cleanup_failed_details">Alguns arquivos não puderam ser excluídos</string>
     <string name="cleanup_cancelled">Limpeza cancelada</string>
     <string name="cleanup_partial">%1$d arquivos excluídos, %2$d falharam</string>
-    <string name="current_streak_label">Sequência atual: %1$d dias seguidos</string>
+    <plurals name="current_streak_label">
+        <item quantity="one">Sequência atual: %1$d dia seguido</item>
+        <item quantity="other">Sequência atual: %1$d dias seguidos</item>
+        <item quantity="many">Sequência atual: %1$d dias seguidos</item>
+    </plurals>
     <string name="longest_streak_label">Maior sequência: recorde de %1$d dias!</string>
 </resources>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -413,6 +413,10 @@
     <string name="cleanup_failed_details">Unele fișiere nu au putut fi șterse</string>
     <string name="cleanup_cancelled">Curățare anulată</string>
     <string name="cleanup_partial">%1$d fișiere șterse, %2$d eșuate</string>
-    <string name="current_streak_label">Seria curentă: %1$d zile la rând</string>
+    <plurals name="current_streak_label">
+        <item quantity="one">Seria curentă: %1$d zi la rând</item>
+        <item quantity="few">Seria curentă: %1$d zile la rând</item>
+        <item quantity="other">Seria curentă: %1$d zile la rând</item>
+    </plurals>
     <string name="longest_streak_label">Cea mai lungă serie: record de %1$d zile!</string>
 </resources>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -421,6 +421,11 @@
     <string name="cleanup_failed_details">Некоторые файлы не удалось удалить</string>
     <string name="cleanup_cancelled">Очистка отменена</string>
     <string name="cleanup_partial">%1$d файлов удалено, %2$d не удалось</string>
-    <string name="current_streak_label">Текущая серия: %1$d дней подряд</string>
+    <plurals name="current_streak_label">
+        <item quantity="one">Текущая серия: %1$d день подряд</item>
+        <item quantity="few">Текущая серия: %1$d дня подряд</item>
+        <item quantity="many">Текущая серия: %1$d дней подряд</item>
+        <item quantity="other">Текущая серия: %1$d дней подряд</item>
+    </plurals>
     <string name="longest_streak_label">Самая длинная серия: рекорд %1$d дней!</string>
 </resources>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -405,6 +405,9 @@
     <string name="cleanup_failed_details">Vissa filer kunde inte tas bort</string>
     <string name="cleanup_cancelled">Rensning avbruten</string>
     <string name="cleanup_partial">%1$d filer raderades, %2$d misslyckades</string>
-    <string name="current_streak_label">Aktuell svit: %1$d dagar i rad</string>
+    <plurals name="current_streak_label">
+        <item quantity="one">Aktuell svit: %1$d dag i rad</item>
+        <item quantity="other">Aktuell svit: %1$d dagar i rad</item>
+    </plurals>
     <string name="longest_streak_label">Längsta svit: rekord på %1$d dagar!</string>
 </resources>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -397,6 +397,8 @@
     <string name="cleanup_failed_details">ไม่สามารถลบไฟล์บางไฟล์ได้</string>
     <string name="cleanup_cancelled">ยกเลิกการล้าง</string>
     <string name="cleanup_partial">ลบไฟล์ %1$d ไฟล์แล้ว, ล้มเหลว %2$d ไฟล์</string>
-    <string name="current_streak_label">สตรีคปัจจุบัน: %1$d วันติดต่อกัน</string>
+    <plurals name="current_streak_label">
+        <item quantity="other">สตรีคปัจจุบัน: %1$d วันติดต่อกัน</item>
+    </plurals>
     <string name="longest_streak_label">สตรีคที่ยาวที่สุด: สถิติ %1$d วัน!</string>
 </resources>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -405,6 +405,9 @@
     <string name="cleanup_failed_details">Bazı dosyalar silinemedi</string>
     <string name="cleanup_cancelled">Temizlik iptal edildi</string>
     <string name="cleanup_partial">%1$d dosya silindi, %2$d başarısız oldu</string>
-    <string name="current_streak_label">Mevcut seri: art arda %1$d gün</string>
+    <plurals name="current_streak_label">
+        <item quantity="one">Mevcut seri: art arda %1$d gün</item>
+        <item quantity="other">Mevcut seri: art arda %1$d gün</item>
+    </plurals>
     <string name="longest_streak_label">En uzun seri: %1$d günlük rekor!</string>
 </resources>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -421,6 +421,11 @@
     <string name="cleanup_failed_details">Деякі файли не вдалося видалити</string>
     <string name="cleanup_cancelled">Очищення скасовано</string>
     <string name="cleanup_partial">Видалено %1$d файлів, %2$d не вдалося</string>
-    <string name="current_streak_label">Поточна серія: %1$d днів поспіль</string>
+    <plurals name="current_streak_label">
+        <item quantity="one">Поточна серія: %1$d день поспіль</item>
+        <item quantity="few">Поточна серія: %1$d дні поспіль</item>
+        <item quantity="many">Поточна серія: %1$d днів поспіль</item>
+        <item quantity="other">Поточна серія: %1$d днів поспіль</item>
+    </plurals>
     <string name="longest_streak_label">Найдовша серія: рекорд %1$d днів!</string>
 </resources>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -405,6 +405,9 @@
     <string name="cleanup_failed_details">کچھ فائلیں حذف نہیں ہو سکیں</string>
     <string name="cleanup_cancelled">صفائی منسوخ کی گئی</string>
     <string name="cleanup_partial">%1$d فائلیں حذف ہوئیں، %2$d ناکام ہوئیں</string>
-    <string name="current_streak_label">موجودہ سلسلہ: مسلسل %1$d دن</string>
+    <plurals name="current_streak_label">
+        <item quantity="one">موجودہ سلسلہ: مسلسل %1$d دن</item>
+        <item quantity="other">موجودہ سلسلہ: مسلسل %1$d دن</item>
+    </plurals>
     <string name="longest_streak_label">طویل ترین سلسلہ: %1$d دن کا ریکارڈ!</string>
 </resources>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -397,6 +397,8 @@
     <string name="cleanup_failed_details">Không thể xóa một số tệp</string>
     <string name="cleanup_cancelled">Đã hủy dọn dẹp</string>
     <string name="cleanup_partial">%1$d tệp đã xóa, %2$d thất bại</string>
-    <string name="current_streak_label">Chuỗi hiện tại: %1$d ngày liên tiếp</string>
+    <plurals name="current_streak_label">
+        <item quantity="other">Chuỗi hiện tại: %1$d ngày liên tiếp</item>
+    </plurals>
     <string name="longest_streak_label">Chuỗi dài nhất: kỷ lục %1$d ngày!</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -397,6 +397,8 @@
     <string name="cleanup_failed_details">部分檔案無法刪除</string>
     <string name="cleanup_cancelled">清理已取消</string>
     <string name="cleanup_partial">已刪除 %1$d 個檔案，%2$d 個失敗</string>
-    <string name="current_streak_label">目前連續天數：%1$d 天</string>
+    <plurals name="current_streak_label">
+        <item quantity="other">目前連續天數：%1$d 天</item>
+    </plurals>
     <string name="longest_streak_label">最長連續紀錄：%1$d 天！</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,7 +98,10 @@
         <item quantity="other">%1$d days in a row — keep it up!</item>
     </plurals>
     <string name="clean_streak_perfect_week_message">Perfect week! 💎 You\'ve earned it.</string>
-    <string name="current_streak_label">Current streak: %1$d days in a row</string>
+    <plurals name="current_streak_label">
+        <item quantity="one">Current streak: %1$d day in a row</item>
+        <item quantity="other">Current streak: %1$d days in a row</item>
+    </plurals>
     <string name="longest_streak_label">Longest streak: %1$d-day record!</string>
     <string name="streak_notification_title">Keep your Clean Streak going!</string>
     <string name="streak_notification_daily">Time to clean up your device and keep your streak going.</string>


### PR DESCRIPTION
## Summary
- convert current streak label to a plural resource with singular and plural forms
- update WeeklyCleanStreakCard to use pluralStringResource
- localize plural forms for all supported languages

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689998ef10e4832d85f7726290481de3