### PR TITLE
Use plurals for empty folder count

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/EmptyFolderCleanerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/EmptyFolderCleanerCard.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.SmallVerticalSpacer
 import com.d4rk.cleaner.R
@@ -32,7 +33,7 @@ fun EmptyFolderCleanerCard(
     ) {
         SmallVerticalSpacer()
         Text(
-            text = stringResource(id = R.string.empty_folders_found_format, folders.size),
+            text = pluralStringResource(id = R.plurals.empty_folders_found_format, count = folders.size, folders.size),
             style = MaterialTheme.typography.bodyMedium,
             modifier = Modifier.animateContentSize()
         )

--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -130,7 +130,10 @@
     <string name="clean_apks">حذف المثبتات</string>
     <string name="empty_folder_card_title">المجلدات الفارغة</string>
     <string name="empty_folder_card_subtitle">احذف المجلدات غير المستخدمة فوراً.</string>
-    <string name="empty_folders_found_format">%1$d مجلد فارغ تم العثور عليه</string>
+    <plurals name="empty_folders_found_format">
+        <item quantity="one">تم العثور على %1$d مجلد فارغ</item>
+        <item quantity="other">تم العثور على %1$d مجلدًا فارغًا</item>
+    </plurals>
     <string name="clean_empty_folders">حذف المجلدات الفاضية</string>
     <string name="whatsapp_card_title">ملفات واتساب</string>
     <string name="whatsapp_card_subtitle">امسح الوسائط التي لم تعد تحتاجها.</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -118,7 +118,10 @@
     <string name="clean_apks">Изтрий инсталаторите</string>
     <string name="empty_folder_card_title">Празни папки</string>
     <string name="empty_folder_card_subtitle">Премахнете неизползваните папки веднага.</string>
-    <string name="empty_folders_found_format">%1$d празни папки намерени</string>
+    <plurals name="empty_folders_found_format">
+        <item quantity="one">Намерена %1$d празна папка</item>
+        <item quantity="other">Намерени %1$d празни папки</item>
+    </plurals>
     <string name="clean_empty_folders">Изтриване на празни папки</string>
     <string name="whatsapp_card_title">Файлове от WhatsApp</string>
     <string name="whatsapp_card_subtitle">Изчистете медията, която вече не ви трябва.</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -118,7 +118,10 @@
     <string name="clean_apks">ইনস্টলার ডিলিট করুন</string>
     <string name="empty_folder_card_title">খালি ফোল্ডার</string>
     <string name="empty_folder_card_subtitle">অব্যবহৃত ফোল্ডার সাথে সাথে মুছে ফেলুন।</string>
-    <string name="empty_folders_found_format">%1$d টি খালি ফোল্ডার পাওয়া গেছে</string>
+    <plurals name="empty_folders_found_format">
+        <item quantity="one">%1$d টি খালি ফোল্ডার পাওয়া গেছে</item>
+        <item quantity="other">%1$d টি খালি ফোল্ডার পাওয়া গেছে</item>
+    </plurals>
     <string name="clean_empty_folders">খালি ফোল্ডার মুছুন</string>
     <string name="whatsapp_card_title">হোয়াটসঅ্যাপ ফাইল</string>
     <string name="whatsapp_card_subtitle">আপনার দরকার নেই এমন মিডিয়া সরান।</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -118,7 +118,10 @@
     <string name="clean_apks">Installer löschen</string>
     <string name="empty_folder_card_title">Leere Ordner</string>
     <string name="empty_folder_card_subtitle">Nicht genutzte Ordner sofort entfernen.</string>
-    <string name="empty_folders_found_format">%1$d leere Ordner gefunden</string>
+    <plurals name="empty_folders_found_format">
+        <item quantity="one">%1$d leerer Ordner gefunden</item>
+        <item quantity="other">%1$d leere Ordner gefunden</item>
+    </plurals>
     <string name="clean_empty_folders">Leere Ordner löschen</string>
     <string name="whatsapp_card_title">WhatsApp-Dateien</string>
     <string name="whatsapp_card_subtitle">Lösche Medien, die du nicht mehr brauchst.</string>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -121,7 +121,10 @@
     <string name="clean_apks">Eliminar instaladores</string>
     <string name="empty_folder_card_title">Carpetas vacías</string>
     <string name="empty_folder_card_subtitle">Elimina las carpetas sin uso al instante.</string>
-    <string name="empty_folders_found_format">%1$d carpetas vacías encontradas</string>
+    <plurals name="empty_folders_found_format">
+        <item quantity="one">%1$d carpeta vacía encontrada</item>
+        <item quantity="other">%1$d carpetas vacías encontradas</item>
+    </plurals>
     <string name="clean_empty_folders">Eliminar carpetas vacías</string>
     <string name="whatsapp_card_title">Archivos de WhatsApp</string>
     <string name="whatsapp_card_subtitle">Elimina los archivos que ya no necesites.</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -121,7 +121,10 @@
     <string name="clean_apks">Eliminar instaladores</string>
     <string name="empty_folder_card_title">Carpetas vacías</string>
     <string name="empty_folder_card_subtitle">Elimina las carpetas sin uso al instante.</string>
-    <string name="empty_folders_found_format">%1$d carpetas vacías encontradas</string>
+    <plurals name="empty_folders_found_format">
+        <item quantity="one">%1$d carpeta vacía encontrada</item>
+        <item quantity="other">%1$d carpetas vacías encontradas</item>
+    </plurals>
     <string name="clean_empty_folders">Eliminar carpetas vacías</string>
     <string name="whatsapp_card_title">Archivos de WhatsApp</string>
     <string name="whatsapp_card_subtitle">Elimina los archivos que ya no necesites.</string>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -118,7 +118,10 @@
     <string name="clean_apks">Burahin ang mga Installer</string>
     <string name="empty_folder_card_title">Walang laman na mga folder</string>
     <string name="empty_folder_card_subtitle">Agad na tanggalin ang hindi nagagamit na mga folder.</string>
-    <string name="empty_folders_found_format">%1$d na walang laman na folder ang nakita</string>
+    <plurals name="empty_folders_found_format">
+        <item quantity="one">%1$d na walang laman na folder ang nakita</item>
+        <item quantity="other">%1$d na walang laman na folder ang nakita</item>
+    </plurals>
     <string name="clean_empty_folders">Burahin ang mga walang lamang folder</string>
     <string name="whatsapp_card_title">Mga WhatsApp File</string>
     <string name="whatsapp_card_subtitle">Linisin ang media na hindi mo na kailangan.</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -121,7 +121,10 @@
     <string name="clean_apks">Supprimer les installateurs</string>
     <string name="empty_folder_card_title">Dossiers vides</string>
     <string name="empty_folder_card_subtitle">Supprimez instantanément les dossiers inutilisés.</string>
-    <string name="empty_folders_found_format">%1$d dossiers vides trouvés</string>
+    <plurals name="empty_folders_found_format">
+        <item quantity="one">%1$d dossier vide trouvé</item>
+        <item quantity="other">%1$d dossiers vides trouvés</item>
+    </plurals>
     <string name="clean_empty_folders">Supprimer les dossiers vides</string>
     <string name="whatsapp_card_title">Fichiers WhatsApp</string>
     <string name="whatsapp_card_subtitle">Nettoyez les médias dont vous n’avez plus besoin.</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -118,7 +118,10 @@
     <string name="clean_apks">इंस्टॉलर हटाएँ</string>
     <string name="empty_folder_card_title">खाली फ़ोल्डर</string>
     <string name="empty_folder_card_subtitle">अनउपयोगी फ़ोल्डर तुरंत हटाएँ।</string>
-    <string name="empty_folders_found_format">%1$d खाली फ़ोल्डर मिले</string>
+    <plurals name="empty_folders_found_format">
+        <item quantity="one">%1$d खाली फ़ोल्डर मिला</item>
+        <item quantity="other">%1$d खाली फ़ोल्डर मिले</item>
+    </plurals>
     <string name="clean_empty_folders">खाली फ़ोल्डर हटाएं</string>
     <string name="whatsapp_card_title">व्हाट्सएप फ़ाइलें</string>
     <string name="whatsapp_card_subtitle">वे मीडिया हटाएँ जिनकी अब ज़रूरत नहीं.</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -118,7 +118,10 @@
     <string name="clean_apks">Telepítők törlése</string>
     <string name="empty_folder_card_title">Üres mappák</string>
     <string name="empty_folder_card_subtitle">A nem használt mappákat azonnal töröld.</string>
-    <string name="empty_folders_found_format">%1$d üres mappa található</string>
+    <plurals name="empty_folders_found_format">
+        <item quantity="one">%1$d üres mappa található</item>
+        <item quantity="other">%1$d üres mappa található</item>
+    </plurals>
     <string name="clean_empty_folders">Üres mappák törlése</string>
     <string name="whatsapp_card_title">WhatsApp fájlok</string>
     <string name="whatsapp_card_subtitle">Törölje a már nem szükséges médiát.</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -115,7 +115,10 @@
     <string name="clean_apks">Hapus Pemasang</string>
     <string name="empty_folder_card_title">Folder Kosong</string>
     <string name="empty_folder_card_subtitle">Hapus folder yang tidak terpakai seketika.</string>
-    <string name="empty_folders_found_format">Ditemukan %1$d folder kosong</string>
+    <plurals name="empty_folders_found_format">
+        <item quantity="one">Ditemukan %1$d folder kosong</item>
+        <item quantity="other">Ditemukan %1$d folder kosong</item>
+    </plurals>
     <string name="clean_empty_folders">Hapus folder kosong</string>
     <string name="whatsapp_card_title">File WhatsApp</string>
     <string name="whatsapp_card_subtitle">Bersihkan media yang tidak lagi dibutuhkan.</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -121,7 +121,10 @@
     <string name="clean_apks">Elimina installatori</string>
     <string name="empty_folder_card_title">Cartelle vuote</string>
     <string name="empty_folder_card_subtitle">Rimuovi subito le cartelle inutilizzate.</string>
-    <string name="empty_folders_found_format">Trovate %1$d cartelle vuote</string>
+    <plurals name="empty_folders_found_format">
+        <item quantity="one">Trovata %1$d cartella vuota</item>
+        <item quantity="other">Trovate %1$d cartelle vuote</item>
+    </plurals>
     <string name="clean_empty_folders">Elimina cartelle vuote</string>
     <string name="whatsapp_card_title">File WhatsApp</string>
     <string name="whatsapp_card_subtitle">Elimina i media di cui non hai più bisogno.</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -115,7 +115,10 @@
     <string name="clean_apks">インストーラーを削除</string>
     <string name="empty_folder_card_title">空のフォルダ</string>
     <string name="empty_folder_card_subtitle">未使用のフォルダをすぐに削除します。</string>
-    <string name="empty_folders_found_format">%1$d 個の空フォルダが見つかりました</string>
+    <plurals name="empty_folders_found_format">
+        <item quantity="one">%1$d 個の空フォルダが見つかりました</item>
+        <item quantity="other">%1$d 個の空フォルダが見つかりました</item>
+    </plurals>
     <string name="clean_empty_folders">空のフォルダを削除</string>
     <string name="whatsapp_card_title">WhatsAppファイル</string>
     <string name="whatsapp_card_subtitle">不要になったメディアを整理します。</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -115,7 +115,10 @@
     <string name="clean_apks">설치 프로그램 삭제</string>
     <string name="empty_folder_card_title">빈 폴더</string>
     <string name="empty_folder_card_subtitle">사용하지 않는 폴더를 즉시 삭제합니다.</string>
-    <string name="empty_folders_found_format">빈 폴더 %1$d개 발견</string>
+    <plurals name="empty_folders_found_format">
+        <item quantity="one">빈 폴더 %1$d개 발견</item>
+        <item quantity="other">빈 폴더 %1$d개 발견</item>
+    </plurals>
     <string name="clean_empty_folders">빈 폴더 삭제</string>
     <string name="whatsapp_card_title">WhatsApp 파일</string>
     <string name="whatsapp_card_subtitle">더 이상 필요 없는 미디어를 정리하세요.</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -124,7 +124,12 @@
     <string name="clean_apks">Usuń instalatory</string>
     <string name="empty_folder_card_title">Puste foldery</string>
     <string name="empty_folder_card_subtitle">Usuń nieużywane foldery natychmiast.</string>
-    <string name="empty_folders_found_format">Znaleziono %1$d pustych folderów</string>
+    <plurals name="empty_folders_found_format">
+        <item quantity="one">Znaleziono %1$d pusty folder</item>
+        <item quantity="few">Znaleziono %1$d puste foldery</item>
+        <item quantity="many">Znaleziono %1$d pustych folderów</item>
+        <item quantity="other">Znaleziono %1$d pustych folderów</item>
+    </plurals>
     <string name="clean_empty_folders">Usuń puste foldery</string>
     <string name="whatsapp_card_title">Pliki WhatsApp</string>
     <string name="whatsapp_card_subtitle">Wyczyść media, których już nie potrzebujesz.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -121,7 +121,11 @@
     <string name="clean_apks">Excluir instaladores</string>
     <string name="empty_folder_card_title">Pastas vazias</string>
     <string name="empty_folder_card_subtitle">Remova pastas não usadas instantaneamente.</string>
-    <string name="empty_folders_found_format">%1$d pastas vazias encontradas</string>
+    <plurals name="empty_folders_found_format">
+        <item quantity="one">%1$d pasta vazia encontrada</item>
+        <item quantity="other">%1$d pastas vazias encontradas</item>
+        <item quantity="many">%1$d pastas vazias encontradas</item>
+    </plurals>
     <string name="clean_empty_folders">Excluir pastas vazias</string>
     <string name="whatsapp_card_title">Arquivos do WhatsApp</string>
     <string name="whatsapp_card_subtitle">Limpe as mídias de que você não precisa mais.</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -121,7 +121,10 @@
     <string name="clean_apks">Șterge instalatoarele</string>
     <string name="empty_folder_card_title">Foldere goale</string>
     <string name="empty_folder_card_subtitle">Șterge instant folderele nefolosite.</string>
-    <string name="empty_folders_found_format">S-au găsit %1$d foldere goale</string>
+    <plurals name="empty_folders_found_format">
+        <item quantity="one">S-a găsit %1$d folder gol</item>
+        <item quantity="other">S-au găsit %1$d foldere goale</item>
+    </plurals>
     <string name="clean_empty_folders">Șterge folderele goale</string>
     <string name="whatsapp_card_title">Fișiere WhatsApp</string>
     <string name="whatsapp_card_subtitle">Curăță fișierele media de care nu mai ai nevoie.</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -124,7 +124,12 @@
     <string name="clean_apks">Удалить установщики</string>
     <string name="empty_folder_card_title">Пустые папки</string>
     <string name="empty_folder_card_subtitle">Мгновенно удаляйте неиспользуемые папки.</string>
-    <string name="empty_folders_found_format">Найдено %1$d пустых папок</string>
+    <plurals name="empty_folders_found_format">
+        <item quantity="one">Найдена %1$d пустая папка</item>
+        <item quantity="few">Найдены %1$d пустые папки</item>
+        <item quantity="many">Найдено %1$d пустых папок</item>
+        <item quantity="other">Найдено %1$d пустых папок</item>
+    </plurals>
     <string name="clean_empty_folders">Удалить пустые папки</string>
     <string name="whatsapp_card_title">Файлы WhatsApp</string>
     <string name="whatsapp_card_subtitle">Очистите медиа, которые вам больше не нужны.</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -118,7 +118,10 @@
     <string name="clean_apks">Ta bort installerare</string>
     <string name="empty_folder_card_title">Tomma mappar</string>
     <string name="empty_folder_card_subtitle">Ta bort oanvända mappar direkt.</string>
-    <string name="empty_folders_found_format">%1$d tomma mappar hittades</string>
+    <plurals name="empty_folders_found_format">
+        <item quantity="one">%1$d tom mapp hittades</item>
+        <item quantity="other">%1$d tomma mappar hittades</item>
+    </plurals>
     <string name="clean_empty_folders">Radera tomma mappar</string>
     <string name="whatsapp_card_title">WhatsApp-filer</string>
     <string name="whatsapp_card_subtitle">Rensa bort media du inte längre behöver.</string>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -115,7 +115,10 @@
     <string name="clean_apks">ลบตัวติดตั้ง</string>
     <string name="empty_folder_card_title">โฟลเดอร์ว่าง</string>
     <string name="empty_folder_card_subtitle">ลบโฟลเดอร์ที่ไม่ได้ใช้ทันที</string>
-    <string name="empty_folders_found_format">พบโฟลเดอร์ว่าง %1$d โฟลเดอร์</string>
+    <plurals name="empty_folders_found_format">
+        <item quantity="one">พบโฟลเดอร์ว่าง %1$d โฟลเดอร์</item>
+        <item quantity="other">พบโฟลเดอร์ว่าง %1$d โฟลเดอร์</item>
+    </plurals>
     <string name="clean_empty_folders">ลบโฟลเดอร์ว่าง</string>
     <string name="whatsapp_card_title">ไฟล์ WhatsApp</string>
     <string name="whatsapp_card_subtitle">ล้างสื่อที่คุณไม่ต้องการแล้ว</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -118,7 +118,10 @@
     <string name="clean_apks">Yükleyicileri Sil</string>
     <string name="empty_folder_card_title">Boş Klasörler</string>
     <string name="empty_folder_card_subtitle">Kullanılmayan klasörleri anında sil.</string>
-    <string name="empty_folders_found_format">%1$d boş klasör bulundu</string>
+    <plurals name="empty_folders_found_format">
+        <item quantity="one">%1$d boş klasör bulundu</item>
+        <item quantity="other">%1$d boş klasör bulundu</item>
+    </plurals>
     <string name="clean_empty_folders">Boş klasörleri sil</string>
     <string name="whatsapp_card_title">WhatsApp Dosyaları</string>
     <string name="whatsapp_card_subtitle">Artık ihtiyaç duymadığın medyaları temizle.</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -124,7 +124,12 @@
     <string name="clean_apks">Видалити інсталятори</string>
     <string name="empty_folder_card_title">Порожні папки</string>
     <string name="empty_folder_card_subtitle">Видаліть невикористані папки миттєво.</string>
-    <string name="empty_folders_found_format">Знайдено %1$d порожніх папок</string>
+    <plurals name="empty_folders_found_format">
+        <item quantity="one">Знайдено %1$d порожню папку</item>
+        <item quantity="few">Знайдено %1$d порожні папки</item>
+        <item quantity="many">Знайдено %1$d порожніх папок</item>
+        <item quantity="other">Знайдено %1$d порожніх папок</item>
+    </plurals>
     <string name="clean_empty_folders">Видаляти порожні теки</string>
     <string name="whatsapp_card_title">Файли WhatsApp</string>
     <string name="whatsapp_card_subtitle">Очистіть медіа, які більше не потрібні.</string>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -118,7 +118,10 @@
     <string name="clean_apks">انسٹالرز حذف کریں</string>
     <string name="empty_folder_card_title">خالی فولڈرز</string>
     <string name="empty_folder_card_subtitle">غیر استعمال شدہ فولڈرز فوراً حذف کریں۔</string>
-    <string name="empty_folders_found_format">%1$d خالی فولڈرز ملے</string>
+    <plurals name="empty_folders_found_format">
+        <item quantity="one">%1$d خالی فولڈر ملا</item>
+        <item quantity="other">%1$d خالی فولڈرز ملے</item>
+    </plurals>
     <string name="clean_empty_folders">خالی فولڈرز حذف کریں</string>
     <string name="whatsapp_card_title">واٹس ایپ فائلیں</string>
     <string name="whatsapp_card_subtitle">وہ میڈیا صاف کریں جس کی آپ کو ضرورت نہیں۔</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -115,7 +115,10 @@
     <string name="clean_apks">Xóa bộ cài</string>
     <string name="empty_folder_card_title">Thư mục trống</string>
     <string name="empty_folder_card_subtitle">Xóa ngay các thư mục không dùng.</string>
-    <string name="empty_folders_found_format">Tìm thấy %1$d thư mục trống</string>
+    <plurals name="empty_folders_found_format">
+        <item quantity="one">Tìm thấy %1$d thư mục trống</item>
+        <item quantity="other">Tìm thấy %1$d thư mục trống</item>
+    </plurals>
     <string name="clean_empty_folders">Xóa thư mục trống</string>
     <string name="whatsapp_card_title">Tệp WhatsApp</string>
     <string name="whatsapp_card_subtitle">Dọn dẹp phương tiện bạn không cần nữa.</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -115,7 +115,10 @@
     <string name="clean_apks">刪除安裝檔</string>
     <string name="empty_folder_card_title">空資料夾</string>
     <string name="empty_folder_card_subtitle">立即移除未使用的資料夾。</string>
-    <string name="empty_folders_found_format">找到 %1$d 個空資料夾</string>
+    <plurals name="empty_folders_found_format">
+        <item quantity="one">找到 %1$d 個空資料夾</item>
+        <item quantity="other">找到 %1$d 個空資料夾</item>
+    </plurals>
     <string name="clean_empty_folders">刪除空資料夾</string>
     <string name="whatsapp_card_title">WhatsApp 檔案</string>
     <string name="whatsapp_card_subtitle">清除不需要的媒體。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -123,7 +123,10 @@
     <string name="clean_apks">Delete Installers</string>
     <string name="empty_folder_card_title">Empty Folders</string>
     <string name="empty_folder_card_subtitle">Remove unused folders instantly.</string>
-    <string name="empty_folders_found_format">%1$d empty folders found</string>
+    <plurals name="empty_folders_found_format">
+        <item quantity="one">%1$d empty folder found</item>
+        <item quantity="other">%1$d empty folders found</item>
+    </plurals>
     <string name="clean_empty_folders">Delete Empty Folders</string>
     <string name="whatsapp_card_title">WhatsApp Files</string>
     <string name="whatsapp_card_subtitle">Clear out media you no longer need.</string>


### PR DESCRIPTION
## Summary
- replace `empty_folders_found_format` string with plural resources across locales
- use `pluralStringResource` to render folder count

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68999d38f478832db426ae55f1060fa5