### PR TITLE
Handle cleanup string pluralization

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/components/CleaningAnimationScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/components/CleaningAnimationScreen.kt
@@ -15,7 +15,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.pluralStringResource
 import com.airbnb.lottie.compose.LottieAnimation
 import com.airbnb.lottie.compose.LottieCompositionSpec
 import com.airbnb.lottie.compose.LottieConstants
@@ -62,7 +62,7 @@ fun CleaningAnimationScreen(
         LargeVerticalSpacer()
 
         Text(
-            text = stringResource(id = R.string.cleanup_progress, cleaned, total),
+            text = pluralStringResource(R.plurals.cleanup_progress, total, cleaned, total),
             style = MaterialTheme.typography.bodyMedium
         )
     }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/largefiles/ui/LargeFilesViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/largefiles/ui/LargeFilesViewModel.kt
@@ -195,9 +195,13 @@ class LargeFilesViewModel(
                 onEvent(LargeFilesEvent.LoadLargeFiles)
 
                 val message = if (failedCount > 0) {
-                    UiTextHelper.StringResource(
-                        R.string.cleanup_partial,
-                        listOf(successCount, failedCount)
+                    UiTextHelper.DynamicString(
+                        application.resources.getQuantityString(
+                            R.plurals.cleanup_partial,
+                            successCount,
+                            successCount,
+                            failedCount,
+                        )
                     )
                 } else {
                     UiTextHelper.StringResource(R.string.all_clean)

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
@@ -612,9 +612,13 @@ class ScannerViewModel(
                 val successCount = selectedCount - failedCount
 
                 val message = if (failedCount > 0) {
-                    UiTextHelper.StringResource(
-                        R.string.cleanup_partial,
-                        listOf(successCount, failedCount)
+                    UiTextHelper.DynamicString(
+                        application.resources.getQuantityString(
+                            R.plurals.cleanup_partial,
+                            successCount,
+                            successCount,
+                            failedCount,
+                        )
                     )
                 } else {
                     UiTextHelper.StringResource(R.string.all_clean)

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/work/FileCleanupWorker.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/work/FileCleanupWorker.kt
@@ -104,8 +104,9 @@ class FileCleanupWorker(
         var processed = 0
         builder.setProgress(total, processed, false)
             .setContentText(
-                applicationContext.getString(
-                    R.string.cleanup_progress,
+                applicationContext.resources.getQuantityString(
+                    R.plurals.cleanup_progress,
+                    total,
                     processed,
                     total,
                 ),
@@ -163,8 +164,9 @@ class FileCleanupWorker(
             processed++
             builder.setProgress(total, processed, false)
                 .setContentText(
-                    applicationContext.getString(
-                        R.string.cleanup_progress,
+                    applicationContext.resources.getQuantityString(
+                        R.plurals.cleanup_progress,
+                        total,
                         processed,
                         total,
                     ),
@@ -227,8 +229,9 @@ class FileCleanupWorker(
                 if (hasPermission) {
                     builder.setContentTitle(applicationContext.getString(R.string.cleanup_finished))
                         .setContentText(
-                            applicationContext.getString(
-                                R.string.cleanup_partial,
+                            applicationContext.resources.getQuantityString(
+                                R.plurals.cleanup_partial,
+                                successCount,
                                 successCount,
                                 failedCount,
                             ),

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/trash/ui/TrashViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/trash/ui/TrashViewModel.kt
@@ -121,9 +121,13 @@ class TrashViewModel(
                 }
 
                 val message = if (failedCount > 0) {
-                    UiTextHelper.StringResource(
-                        R.string.cleanup_partial,
-                        listOf(successCount, failedCount)
+                    UiTextHelper.DynamicString(
+                        application.resources.getQuantityString(
+                            R.plurals.cleanup_partial,
+                            successCount,
+                            successCount,
+                            failedCount,
+                        )
                     )
                 } else {
                     UiTextHelper.StringResource(R.string.all_clean)

--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -434,12 +434,26 @@
     <string name="failed_to_update_trash_size">فشل في تحديث حجم القمامة: %1$s</string>
     <string name="no_cleaning_options_selected">يرجى اختيار تفضيلات التنظيف الخاصة بك في الإعدادات للمتابعة.</string>
     <string name="cleaning_in_progress">جاري التنظيف</string>
-    <string name="cleanup_progress">تم تنظيف %1$d/%2$d ملف</string>
+    <plurals name="cleanup_progress">
+        <item quantity="zero">تم تنظيف %1$d/%2$d ملف</item>
+        <item quantity="one">تم تنظيف %1$d/%2$d ملف</item>
+        <item quantity="two">تم تنظيف %1$d/%2$d ملفين</item>
+        <item quantity="few">تم تنظيف %1$d/%2$d ملفات</item>
+        <item quantity="many">تم تنظيف %1$d/%2$d ملفًا</item>
+        <item quantity="other">تم تنظيف %1$d/%2$d ملف</item>
+    </plurals>
     <string name="cleanup_finished">اكتمل التنظيف</string>
     <string name="cleanup_failed">فشل التنظيف</string>
     <string name="cleanup_failed_details">تعذر حذف بعض الملفات</string>
     <string name="cleanup_cancelled">تم إلغاء التنظيف</string>
-    <string name="cleanup_partial">تم حذف %1$d ملفًا، فشل حذف %2$d</string>
+    <plurals name="cleanup_partial">
+        <item quantity="zero">تم حذف %1$d ملف، فشل حذف %2$d</item>
+        <item quantity="one">تم حذف %1$d ملف، فشل حذف %2$d</item>
+        <item quantity="two">تم حذف %1$d ملفين، فشل حذف %2$d</item>
+        <item quantity="few">تم حذف %1$d ملفات، فشل حذف %2$d</item>
+        <item quantity="many">تم حذف %1$d ملفًا، فشل حذف %2$d</item>
+        <item quantity="other">تم حذف %1$d ملف، فشل حذف %2$d</item>
+    </plurals>
     <plurals name="current_streak_label">
         <item quantity="zero">السلسلة الحالية: %1$d يومًا على التوالي</item>
         <item quantity="one">السلسلة الحالية: %1$d يومًا على التوالي</item>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -401,12 +401,18 @@
     <string name="failed_to_update_trash_size">Неуспешно актуализиране на размера на боклука: %1$s</string>
     <string name="no_cleaning_options_selected">Моля, изберете вашите предпочитания за почистване в настройките, за да продължите.</string>
     <string name="cleaning_in_progress">Почистването е в ход</string>
-    <string name="cleanup_progress">%1$d/%2$d файла почистени</string>
+    <plurals name="cleanup_progress">
+        <item quantity="one">%1$d/%2$d файл почистен</item>
+        <item quantity="other">%1$d/%2$d файла почистени</item>
+    </plurals>
     <string name="cleanup_finished">Почистването приключи</string>
     <string name="cleanup_failed">Почистването се провали</string>
     <string name="cleanup_failed_details">Някои файлове не можаха да бъдат изтрити</string>
     <string name="cleanup_cancelled">Почистването е отменено</string>
-    <string name="cleanup_partial">%1$d файла изтрити, %2$d неуспешни</string>
+    <plurals name="cleanup_partial">
+        <item quantity="one">%1$d файл изтрит, %2$d неуспешни</item>
+        <item quantity="other">%1$d файла изтрити, %2$d неуспешни</item>
+    </plurals>
     <plurals name="current_streak_label">
         <item quantity="one">Текуща серия: %1$d ден подред</item>
         <item quantity="other">Текуща серия: %1$d дни подред</item>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -401,12 +401,18 @@
     <string name="failed_to_update_trash_size">আবর্জনার আকার আপডেট করতে ব্যর্থ: %1$s</string>
     <string name="no_cleaning_options_selected">এগিয়ে যেতে সেটিংসে আপনার পরিষ্কারের পছন্দগুলি চয়ন করুন।</string>
     <string name="cleaning_in_progress">পরিষ্কার চলছে</string>
-    <string name="cleanup_progress">%1$d/%2$d টি ফাইল পরিষ্কার করা হয়েছে</string>
+    <plurals name="cleanup_progress">
+        <item quantity="one">%1$d/%2$d টি ফাইল পরিষ্কার করা হয়েছে</item>
+        <item quantity="other">%1$d/%2$d টি ফাইল পরিষ্কার করা হয়েছে</item>
+    </plurals>
     <string name="cleanup_finished">পরিষ্কার সম্পন্ন</string>
     <string name="cleanup_failed">পরিষ্কার ব্যর্থ হয়েছে</string>
     <string name="cleanup_failed_details">কিছু ফাইল মুছে ফেলা যায়নি</string>
     <string name="cleanup_cancelled">পরিষ্কার বাতিল করা হয়েছে</string>
-    <string name="cleanup_partial">%1$d টি ফাইল মুছে ফেলা হয়েছে, %2$d টি ব্যর্থ হয়েছে</string>
+    <plurals name="cleanup_partial">
+        <item quantity="one">%1$d টি ফাইল মুছে ফেলা হয়েছে, %2$d টি ব্যর্থ হয়েছে</item>
+        <item quantity="other">%1$d টি ফাইল মুছে ফেলা হয়েছে, %2$d টি ব্যর্থ হয়েছে</item>
+    </plurals>
     <plurals name="current_streak_label">
         <item quantity="one">বর্তমান স্ট্রীক: পরপর %1$d দিন</item>
         <item quantity="other">বর্তমান স্ট্রীক: পরপর %1$d দিন</item>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -402,12 +402,18 @@
     <string name="failed_to_update_trash_size">Die Müllgröße nicht aktualisieren: %1$s</string>
     <string name="no_cleaning_options_selected">Bitte wählen Sie Ihre Reinigungseinstellungen in Einstellungen, um fortzufahren.</string>
     <string name="cleaning_in_progress">Reinigung läuft</string>
-    <string name="cleanup_progress">%1$d/%2$d Dateien bereinigt</string>
+    <plurals name="cleanup_progress">
+        <item quantity="one">%1$d/%2$d Datei bereinigt</item>
+        <item quantity="other">%1$d/%2$d Dateien bereinigt</item>
+    </plurals>
     <string name="cleanup_finished">Bereinigung abgeschlossen</string>
     <string name="cleanup_failed">Bereinigung fehlgeschlagen</string>
     <string name="cleanup_failed_details">Einige Dateien konnten nicht gelöscht werden</string>
     <string name="cleanup_cancelled">Bereinigung abgebrochen</string>
-    <string name="cleanup_partial">%1$d Dateien gelöscht, %2$d fehlgeschlagen</string>
+    <plurals name="cleanup_partial">
+        <item quantity="one">%1$d Datei gelöscht, %2$d fehlgeschlagen</item>
+        <item quantity="other">%1$d Dateien gelöscht, %2$d fehlgeschlagen</item>
+    </plurals>
     <plurals name="current_streak_label">
         <item quantity="one">Aktuelle Serie: %1$d Tag infolge</item>
         <item quantity="other">Aktuelle Serie: %1$d Tage infolge</item>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -410,12 +410,18 @@
     <string name="failed_to_update_trash_size">No se pudo actualizar el tamaño de la basura: %1$s</string>
     <string name="no_cleaning_options_selected">Elija sus preferencias de limpieza en Configuración para continuar.</string>
     <string name="cleaning_in_progress">Limpieza en curso</string>
-    <string name="cleanup_progress">%1$d/%2$d archivos limpiados</string>
+    <plurals name="cleanup_progress">
+        <item quantity="one">%1$d/%2$d archivo limpiado</item>
+        <item quantity="other">%1$d/%2$d archivos limpiados</item>
+    </plurals>
     <string name="cleanup_finished">Limpieza finalizada</string>
     <string name="cleanup_failed">Limpieza fallida</string>
     <string name="cleanup_failed_details">No se pudieron eliminar algunos archivos</string>
     <string name="cleanup_cancelled">Limpieza cancelada</string>
-    <string name="cleanup_partial">%1$d archivos eliminados, %2$d fallidos</string>
+    <plurals name="cleanup_partial">
+        <item quantity="one">%1$d archivo eliminado, %2$d fallidos</item>
+        <item quantity="other">%1$d archivos eliminados, %2$d fallidos</item>
+    </plurals>
     <plurals name="current_streak_label">
         <item quantity="one">Racha actual: %1$d día seguido</item>
         <item quantity="many">Racha actual: %1$d días seguidos</item>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -410,12 +410,18 @@
     <string name="failed_to_update_trash_size">No se pudo actualizar el tamaño de la basura: %1$s</string>
     <string name="no_cleaning_options_selected">Elija sus preferencias de limpieza en Configuración para continuar.</string>
     <string name="cleaning_in_progress">Limpieza en curso</string>
-    <string name="cleanup_progress">%1$d/%2$d archivos limpiados</string>
+    <plurals name="cleanup_progress">
+        <item quantity="one">%1$d/%2$d archivo limpiado</item>
+        <item quantity="other">%1$d/%2$d archivos limpiados</item>
+    </plurals>
     <string name="cleanup_finished">Limpieza finalizada</string>
     <string name="cleanup_failed">Limpieza fallida</string>
     <string name="cleanup_failed_details">No se pudieron eliminar algunos archivos</string>
     <string name="cleanup_cancelled">Limpieza cancelada</string>
-    <string name="cleanup_partial">%1$d archivos eliminados, %2$d fallidos</string>
+    <plurals name="cleanup_partial">
+        <item quantity="one">%1$d archivo eliminado, %2$d fallidos</item>
+        <item quantity="other">%1$d archivos eliminados, %2$d fallidos</item>
+    </plurals>
     <plurals name="current_streak_label">
         <item quantity="one">Racha actual: %1$d día seguido</item>
         <item quantity="many">Racha actual: %1$d días seguidos</item>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -402,12 +402,18 @@
     <string name="failed_to_update_trash_size">Nabigong i -update ang laki ng basurahan: %1$s</string>
     <string name="no_cleaning_options_selected">Mangyaring piliin ang iyong mga kagustuhan sa paglilinis sa mga setting upang magpatuloy.</string>
     <string name="cleaning_in_progress">Isinasagawa ang paglilinis</string>
-    <string name="cleanup_progress">%1$d/%2$d file nalinis</string>
+    <plurals name="cleanup_progress">
+        <item quantity="one">%1$d/%2$d file nalinis</item>
+        <item quantity="other">%1$d/%2$d file nalinis</item>
+    </plurals>
     <string name="cleanup_finished">Tapos na ang paglilinis</string>
     <string name="cleanup_failed">Nabigo ang paglilinis</string>
     <string name="cleanup_failed_details">May ilang file na hindi matanggal</string>
     <string name="cleanup_cancelled">Kinansela ang paglilinis</string>
-    <string name="cleanup_partial">Na-delete ang %1$d na file, nabigo ang %2$d</string>
+    <plurals name="cleanup_partial">
+        <item quantity="one">Na-delete ang %1$d na file, nabigo ang %2$d</item>
+        <item quantity="other">Na-delete ang %1$d na file, nabigo ang %2$d</item>
+    </plurals>
     <plurals name="current_streak_label">
         <item quantity="one">Kasalukuyang streak: %1$d araw nang sunod-sunod</item>
         <item quantity="other">Kasalukuyang streak: %1$d araw nang sunod-sunod</item>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -411,12 +411,18 @@
     <string name="failed_to_update_trash_size">Échec de la mise à jour de la taille des poubelles: %1$s</string>
     <string name="no_cleaning_options_selected">Veuillez choisir vos préférences de nettoyage dans les paramètres pour continuer.</string>
     <string name="cleaning_in_progress">Nettoyage en cours</string>
-    <string name="cleanup_progress">%1$d/%2$d fichiers nettoyés</string>
+    <plurals name="cleanup_progress">
+        <item quantity="one">%1$d/%2$d fichier nettoyé</item>
+        <item quantity="other">%1$d/%2$d fichiers nettoyés</item>
+    </plurals>
     <string name="cleanup_finished">Nettoyage terminé</string>
     <string name="cleanup_failed">Échec du nettoyage</string>
     <string name="cleanup_failed_details">Certains fichiers n\'ont pas pu être supprimés</string>
     <string name="cleanup_cancelled">Nettoyage annulé</string>
-    <string name="cleanup_partial">%1$d fichiers supprimés, %2$d échoués</string>
+    <plurals name="cleanup_partial">
+        <item quantity="one">%1$d fichier supprimé, %2$d échoués</item>
+        <item quantity="other">%1$d fichiers supprimés, %2$d échoués</item>
+    </plurals>
     <plurals name="current_streak_label">
         <item quantity="one">Série actuelle : %1$d jour d\'affilée</item>
         <item quantity="many">Série actuelle : %1$d jours d\'affilée</item>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -402,12 +402,18 @@
     <string name="failed_to_update_trash_size">कचरा आकार अपडेट करने में विफल: %1$s</string>
     <string name="no_cleaning_options_selected">कृपया आगे बढ़ने के लिए सेटिंग्स में अपनी सफाई वरीयताएँ चुनें।</string>
     <string name="cleaning_in_progress">सफाई जारी है</string>
-    <string name="cleanup_progress">%1$d/%2$d फ़ाइलें साफ़ की गईं</string>
+    <plurals name="cleanup_progress">
+        <item quantity="one">%1$d/%2$d फ़ाइल साफ़ की गई</item>
+        <item quantity="other">%1$d/%2$d फ़ाइलें साफ़ की गईं</item>
+    </plurals>
     <string name="cleanup_finished">सफाई पूरी हुई</string>
     <string name="cleanup_failed">सफाई असफल रही</string>
     <string name="cleanup_failed_details">कुछ फ़ाइलें हटाई नहीं जा सकीं</string>
     <string name="cleanup_cancelled">सफाई रद्द की गई</string>
-    <string name="cleanup_partial">%1$d फ़ाइलें हटाई गईं, %2$d असफल रहीं</string>
+    <plurals name="cleanup_partial">
+        <item quantity="one">%1$d फ़ाइल हटाई गई, %2$d असफल रहीं</item>
+        <item quantity="other">%1$d फ़ाइलें हटाई गईं, %2$d असफल रहीं</item>
+    </plurals>
     <plurals name="current_streak_label">
         <item quantity="one">वर्तमान स्ट्रीक: लगातार %1$d दिन</item>
         <item quantity="other">वर्तमान स्ट्रीक: लगातार %1$d दिन</item>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -402,12 +402,18 @@
     <string name="failed_to_update_trash_size">Nem sikerült frissíteni a szemét méretét: %1$s</string>
     <string name="no_cleaning_options_selected">Kérjük, válassza ki a tisztítási beállításokat a beállításokban.</string>
     <string name="cleaning_in_progress">Tisztítás folyamatban</string>
-    <string name="cleanup_progress">%1$d/%2$d fájl törölve</string>
+    <plurals name="cleanup_progress">
+        <item quantity="one">%1$d/%2$d fájl törölve</item>
+        <item quantity="other">%1$d/%2$d fájl törölve</item>
+    </plurals>
     <string name="cleanup_finished">Tisztítás befejezve</string>
     <string name="cleanup_failed">Tisztítás sikertelen</string>
     <string name="cleanup_failed_details">Néhány fájlt nem sikerült törölni</string>
     <string name="cleanup_cancelled">Tisztítás megszakítva</string>
-    <string name="cleanup_partial">%1$d fájl törölve, %2$d sikertelen</string>
+    <plurals name="cleanup_partial">
+        <item quantity="one">%1$d fájl törölve, %2$d sikertelen</item>
+        <item quantity="other">%1$d fájl törölve, %2$d sikertelen</item>
+    </plurals>
     <plurals name="current_streak_label">
         <item quantity="one">Jelenlegi sorozat: %1$d nap egymás után</item>
         <item quantity="other">Jelenlegi sorozat: %1$d nap egymás után</item>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -394,12 +394,18 @@
     <string name="failed_to_update_trash_size">Gagal memperbarui ukuran sampah: %1$s</string>
     <string name="no_cleaning_options_selected">Pilih preferensi pembersihan Anda dalam pengaturan untuk melanjutkan.</string>
     <string name="cleaning_in_progress">Pembersihan sedang berlangsung</string>
-    <string name="cleanup_progress">%1$d/%2$d file dibersihkan</string>
+    <plurals name="cleanup_progress">
+        <item quantity="one">%1$d/%2$d file dibersihkan</item>
+        <item quantity="other">%1$d/%2$d file dibersihkan</item>
+    </plurals>
     <string name="cleanup_finished">Pembersihan selesai</string>
     <string name="cleanup_failed">Pembersihan gagal</string>
     <string name="cleanup_failed_details">Beberapa file tidak dapat dihapus</string>
     <string name="cleanup_cancelled">Pembersihan dibatalkan</string>
-    <string name="cleanup_partial">%1$d file dihapus, %2$d gagal</string>
+    <plurals name="cleanup_partial">
+        <item quantity="one">%1$d file dihapus, %2$d gagal</item>
+        <item quantity="other">%1$d file dihapus, %2$d gagal</item>
+    </plurals>
     <plurals name="current_streak_label">
         <item quantity="other">Streak saat ini: %1$d hari berturut-turut</item>
     </plurals>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -410,12 +410,18 @@
     <string name="failed_to_update_trash_size">Impossibile aggiornare la dimensione della spazzatura: %1$s</string>
     <string name="no_cleaning_options_selected">Scegli le tue preferenze di pulizia nelle impostazioni per procedere.</string>
     <string name="cleaning_in_progress">Pulizia in corso</string>
-    <string name="cleanup_progress">%1$d/%2$d file puliti</string>
+    <plurals name="cleanup_progress">
+        <item quantity="one">%1$d/%2$d file pulito</item>
+        <item quantity="other">%1$d/%2$d file puliti</item>
+    </plurals>
     <string name="cleanup_finished">Pulizia completata</string>
     <string name="cleanup_failed">Pulizia non riuscita</string>
     <string name="cleanup_failed_details">Impossibile eliminare alcuni file</string>
     <string name="cleanup_cancelled">Pulizia annullata</string>
-    <string name="cleanup_partial">%1$d file eliminati, %2$d non riusciti</string>
+    <plurals name="cleanup_partial">
+        <item quantity="one">%1$d file eliminato, %2$d non riusciti</item>
+        <item quantity="other">%1$d file eliminati, %2$d non riusciti</item>
+    </plurals>
     <plurals name="current_streak_label">
         <item quantity="one">Serie attuale: %1$d giorno di fila</item>
         <item quantity="many">Serie attuale: %1$d giorni di fila</item>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -394,12 +394,18 @@
     <string name="failed_to_update_trash_size">ゴミのサイズの更新に失敗しました：%1$s</string>
     <string name="no_cleaning_options_selected">続行するには、設定のクリーニング設定を選択してください。</string>
     <string name="cleaning_in_progress">クリーンアップを実行中</string>
-    <string name="cleanup_progress">%1$d/%2$d 件のファイルをクリーンアップ済み</string>
+    <plurals name="cleanup_progress">
+        <item quantity="one">%1$d/%2$d 件のファイルをクリーンアップ済み</item>
+        <item quantity="other">%1$d/%2$d 件のファイルをクリーンアップ済み</item>
+    </plurals>
     <string name="cleanup_finished">クリーンアップ完了</string>
     <string name="cleanup_failed">クリーンアップに失敗しました</string>
     <string name="cleanup_failed_details">一部のファイルを削除できませんでした</string>
     <string name="cleanup_cancelled">クリーンアップをキャンセルしました</string>
-    <string name="cleanup_partial">%1$d 件のファイルを削除、%2$d 件が失敗しました</string>
+    <plurals name="cleanup_partial">
+        <item quantity="one">%1$d 件のファイルを削除、%2$d 件が失敗しました</item>
+        <item quantity="other">%1$d 件のファイルを削除、%2$d 件が失敗しました</item>
+    </plurals>
     <plurals name="current_streak_label">
         <item quantity="other">現在の連続記録：%1$d日連続</item>
     </plurals>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -394,12 +394,18 @@
     <string name="failed_to_update_trash_size">쓰레기 크기를 업데이트하지 못했습니다 : %1$s</string>
     <string name="no_cleaning_options_selected">진행할 설정에서 청소 환경 설정을 선택하십시오.</string>
     <string name="cleaning_in_progress">정리 진행 중</string>
-    <string name="cleanup_progress">%1$d/%2$d개의 파일 정리됨</string>
+    <plurals name="cleanup_progress">
+        <item quantity="one">%1$d/%2$d개의 파일 정리됨</item>
+        <item quantity="other">%1$d/%2$d개의 파일 정리됨</item>
+    </plurals>
     <string name="cleanup_finished">정리 완료</string>
     <string name="cleanup_failed">정리에 실패했습니다</string>
     <string name="cleanup_failed_details">일부 파일을 삭제할 수 없습니다</string>
     <string name="cleanup_cancelled">정리가 취소되었습니다</string>
-    <string name="cleanup_partial">%1$d개의 파일 삭제, %2$d개 실패</string>
+    <plurals name="cleanup_partial">
+        <item quantity="one">%1$d개의 파일 삭제, %2$d개 실패</item>
+        <item quantity="other">%1$d개의 파일 삭제, %2$d개 실패</item>
+    </plurals>
     <plurals name="current_streak_label">
         <item quantity="other">현재 스트릭: %1$d일 연속</item>
     </plurals>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -420,12 +420,22 @@
     <string name="failed_to_update_trash_size">Nie udało się zaktualizować rozmiaru śmieci: %1$s</string>
     <string name="no_cleaning_options_selected">Wybierz swoje preferencje czyszczące w ustawieniach, aby kontynuować.</string>
     <string name="cleaning_in_progress">Trwa czyszczenie</string>
-    <string name="cleanup_progress">%1$d/%2$d plików wyczyszczono</string>
+    <plurals name="cleanup_progress">
+        <item quantity="one">%1$d/%2$d plik wyczyszczono</item>
+        <item quantity="few">%1$d/%2$d pliki wyczyszczono</item>
+        <item quantity="many">%1$d/%2$d plików wyczyszczono</item>
+        <item quantity="other">%1$d/%2$d plików wyczyszczono</item>
+    </plurals>
     <string name="cleanup_finished">Czyszczenie zakończone</string>
     <string name="cleanup_failed">Czyszczenie nie powiodło się</string>
     <string name="cleanup_failed_details">Niektórych plików nie można było usunąć</string>
     <string name="cleanup_cancelled">Czyszczenie anulowane</string>
-    <string name="cleanup_partial">%1$d plików usunięto, %2$d nie powiodło się</string>
+    <plurals name="cleanup_partial">
+        <item quantity="one">%1$d plik usunięto, %2$d nie powiodło się</item>
+        <item quantity="few">%1$d pliki usunięto, %2$d nie powiodło się</item>
+        <item quantity="many">%1$d plików usunięto, %2$d nie powiodło się</item>
+        <item quantity="other">%1$d plików usunięto, %2$d nie powiodło się</item>
+    </plurals>
     <plurals name="current_streak_label">
         <item quantity="one">Obecna passa: %1$d dzień z rzędu</item>
         <item quantity="few">Obecna passa: %1$d dni z rzędu</item>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -411,12 +411,18 @@
     <string name="failed_to_update_trash_size">Falha ao atualizar o tamanho do lixo: %1$s</string>
     <string name="no_cleaning_options_selected">Escolha suas preferências de limpeza nas configurações para prosseguir.</string>
     <string name="cleaning_in_progress">Limpeza em andamento</string>
-    <string name="cleanup_progress">%1$d/%2$d arquivos limpos</string>
+    <plurals name="cleanup_progress">
+        <item quantity="one">%1$d/%2$d arquivo limpo</item>
+        <item quantity="other">%1$d/%2$d arquivos limpos</item>
+    </plurals>
     <string name="cleanup_finished">Limpeza concluída</string>
     <string name="cleanup_failed">Falha na limpeza</string>
     <string name="cleanup_failed_details">Alguns arquivos não puderam ser excluídos</string>
     <string name="cleanup_cancelled">Limpeza cancelada</string>
-    <string name="cleanup_partial">%1$d arquivos excluídos, %2$d falharam</string>
+    <plurals name="cleanup_partial">
+        <item quantity="one">%1$d arquivo excluído, %2$d falharam</item>
+        <item quantity="other">%1$d arquivos excluídos, %2$d falharam</item>
+    </plurals>
     <plurals name="current_streak_label">
         <item quantity="one">Sequência atual: %1$d dia seguido</item>
         <item quantity="other">Sequência atual: %1$d dias seguidos</item>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -410,12 +410,18 @@
     <string name="failed_to_update_trash_size">Nu a reușit să actualizeze dimensiunea gunoiului: %1$s</string>
     <string name="no_cleaning_options_selected">Vă rugăm să alegeți preferințele dvs. de curățare în setări pentru a continua.</string>
     <string name="cleaning_in_progress">Curățare în curs</string>
-    <string name="cleanup_progress">%1$d/%2$d fișiere curățate</string>
+    <plurals name="cleanup_progress">
+        <item quantity="one">%1$d/%2$d fișier curățat</item>
+        <item quantity="other">%1$d/%2$d fișiere curățate</item>
+    </plurals>
     <string name="cleanup_finished">Curățare finalizată</string>
     <string name="cleanup_failed">Curățare eșuată</string>
     <string name="cleanup_failed_details">Unele fișiere nu au putut fi șterse</string>
     <string name="cleanup_cancelled">Curățare anulată</string>
-    <string name="cleanup_partial">%1$d fișiere șterse, %2$d eșuate</string>
+    <plurals name="cleanup_partial">
+        <item quantity="one">%1$d fișier șters, %2$d eșuate</item>
+        <item quantity="other">%1$d fișiere șterse, %2$d eșuate</item>
+    </plurals>
     <plurals name="current_streak_label">
         <item quantity="one">Seria curentă: %1$d zi la rând</item>
         <item quantity="few">Seria curentă: %1$d zile la rând</item>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -420,12 +420,22 @@
     <string name="failed_to_update_trash_size">Не удалось обновить размер мусора: %1$s</string>
     <string name="no_cleaning_options_selected">Пожалуйста, выберите свои предпочтения в уборке в настройках, чтобы продолжить.</string>
     <string name="cleaning_in_progress">Идет очистка</string>
-    <string name="cleanup_progress">Очищено %1$d/%2$d файлов</string>
+    <plurals name="cleanup_progress">
+        <item quantity="one">Очищен %1$d/%2$d файл</item>
+        <item quantity="few">Очищено %1$d/%2$d файла</item>
+        <item quantity="many">Очищено %1$d/%2$d файлов</item>
+        <item quantity="other">Очищено %1$d/%2$d файла</item>
+    </plurals>
     <string name="cleanup_finished">Очистка завершена</string>
     <string name="cleanup_failed">Очистка не удалась</string>
     <string name="cleanup_failed_details">Некоторые файлы не удалось удалить</string>
     <string name="cleanup_cancelled">Очистка отменена</string>
-    <string name="cleanup_partial">%1$d файлов удалено, %2$d не удалось</string>
+    <plurals name="cleanup_partial">
+        <item quantity="one">%1$d файл удален, %2$d не удалось</item>
+        <item quantity="few">%1$d файла удалено, %2$d не удалось</item>
+        <item quantity="many">%1$d файлов удалено, %2$d не удалось</item>
+        <item quantity="other">%1$d файлов удалено, %2$d не удалось</item>
+    </plurals>
     <plurals name="current_streak_label">
         <item quantity="one">Текущая серия: %1$d день подряд</item>
         <item quantity="few">Текущая серия: %1$d дня подряд</item>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -402,12 +402,18 @@
     <string name="failed_to_update_trash_size">Det gick inte att uppdatera skräpstorlek: %1$s</string>
     <string name="no_cleaning_options_selected">Välj dina rengöringspreferenser i inställningar för att fortsätta.</string>
     <string name="cleaning_in_progress">Rensning pågår</string>
-    <string name="cleanup_progress">%1$d/%2$d filer rensade</string>
+    <plurals name="cleanup_progress">
+        <item quantity="one">%1$d/%2$d fil rensad</item>
+        <item quantity="other">%1$d/%2$d filer rensade</item>
+    </plurals>
     <string name="cleanup_finished">Rensning klar</string>
     <string name="cleanup_failed">Rensning misslyckades</string>
     <string name="cleanup_failed_details">Vissa filer kunde inte tas bort</string>
     <string name="cleanup_cancelled">Rensning avbruten</string>
-    <string name="cleanup_partial">%1$d filer raderades, %2$d misslyckades</string>
+    <plurals name="cleanup_partial">
+        <item quantity="one">%1$d fil raderades, %2$d misslyckades</item>
+        <item quantity="other">%1$d filer raderades, %2$d misslyckades</item>
+    </plurals>
     <plurals name="current_streak_label">
         <item quantity="one">Aktuell svit: %1$d dag i rad</item>
         <item quantity="other">Aktuell svit: %1$d dagar i rad</item>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -394,12 +394,18 @@
     <string name="failed_to_update_trash_size">ไม่สามารถอัปเดตขนาดถังขยะ: %1$s</string>
     <string name="no_cleaning_options_selected">โปรดเลือกการตั้งค่าการทำความสะอาดของคุณในการตั้งค่าเพื่อดำเนินการต่อ</string>
     <string name="cleaning_in_progress">กำลังทำความสะอาด</string>
-    <string name="cleanup_progress">ล้างแล้ว %1$d/%2$d ไฟล์</string>
+    <plurals name="cleanup_progress">
+        <item quantity="one">ล้างแล้ว %1$d/%2$d ไฟล์</item>
+        <item quantity="other">ล้างแล้ว %1$d/%2$d ไฟล์</item>
+    </plurals>
     <string name="cleanup_finished">ล้างเสร็จแล้ว</string>
     <string name="cleanup_failed">การล้างล้มเหลว</string>
     <string name="cleanup_failed_details">ไม่สามารถลบไฟล์บางไฟล์ได้</string>
     <string name="cleanup_cancelled">ยกเลิกการล้าง</string>
-    <string name="cleanup_partial">ลบไฟล์ %1$d ไฟล์แล้ว, ล้มเหลว %2$d ไฟล์</string>
+    <plurals name="cleanup_partial">
+        <item quantity="one">ลบไฟล์ %1$d ไฟล์แล้ว, ล้มเหลว %2$d ไฟล์</item>
+        <item quantity="other">ลบไฟล์ %1$d ไฟล์แล้ว, ล้มเหลว %2$d ไฟล์</item>
+    </plurals>
     <plurals name="current_streak_label">
         <item quantity="other">สตรีคปัจจุบัน: %1$d วันติดต่อกัน</item>
     </plurals>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -402,12 +402,18 @@
     <string name="failed_to_update_trash_size">Çöp Boyutunu Güncelleme: %1$s</string>
     <string name="no_cleaning_options_selected">Lütfen devam etmek için ayarlarda temizlik tercihlerinizi seçin.</string>
     <string name="cleaning_in_progress">Temizlik devam ediyor</string>
-    <string name="cleanup_progress">%1$d/%2$d dosya temizlendi</string>
+    <plurals name="cleanup_progress">
+        <item quantity="one">%1$d/%2$d dosya temizlendi</item>
+        <item quantity="other">%1$d/%2$d dosya temizlendi</item>
+    </plurals>
     <string name="cleanup_finished">Temizlik tamamlandı</string>
     <string name="cleanup_failed">Temizlik başarısız</string>
     <string name="cleanup_failed_details">Bazı dosyalar silinemedi</string>
     <string name="cleanup_cancelled">Temizlik iptal edildi</string>
-    <string name="cleanup_partial">%1$d dosya silindi, %2$d başarısız oldu</string>
+    <plurals name="cleanup_partial">
+        <item quantity="one">%1$d dosya silindi, %2$d başarısız oldu</item>
+        <item quantity="other">%1$d dosya silindi, %2$d başarısız oldu</item>
+    </plurals>
     <plurals name="current_streak_label">
         <item quantity="one">Mevcut seri: art arda %1$d gün</item>
         <item quantity="other">Mevcut seri: art arda %1$d gün</item>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -420,12 +420,22 @@
     <string name="failed_to_update_trash_size">Не вдалося оновити розмір сміття: %1$s</string>
     <string name="no_cleaning_options_selected">Будь ласка, виберіть свої вподобання прибирання в налаштуваннях для продовження.</string>
     <string name="cleaning_in_progress">Триває очищення</string>
-    <string name="cleanup_progress">Очищено %1$d/%2$d файлів</string>
+    <plurals name="cleanup_progress">
+        <item quantity="one">Очищено %1$d/%2$d файл</item>
+        <item quantity="few">Очищено %1$d/%2$d файли</item>
+        <item quantity="many">Очищено %1$d/%2$d файлів</item>
+        <item quantity="other">Очищено %1$d/%2$d файлів</item>
+    </plurals>
     <string name="cleanup_finished">Очищення завершено</string>
     <string name="cleanup_failed">Очищення не вдалося</string>
     <string name="cleanup_failed_details">Деякі файли не вдалося видалити</string>
     <string name="cleanup_cancelled">Очищення скасовано</string>
-    <string name="cleanup_partial">Видалено %1$d файлів, %2$d не вдалося</string>
+    <plurals name="cleanup_partial">
+        <item quantity="one">Видалено %1$d файл, %2$d не вдалося</item>
+        <item quantity="few">Видалено %1$d файли, %2$d не вдалося</item>
+        <item quantity="many">Видалено %1$d файлів, %2$d не вдалося</item>
+        <item quantity="other">Видалено %1$d файлів, %2$d не вдалося</item>
+    </plurals>
     <plurals name="current_streak_label">
         <item quantity="one">Поточна серія: %1$d день поспіль</item>
         <item quantity="few">Поточна серія: %1$d дні поспіль</item>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -402,12 +402,18 @@
     <string name="failed_to_update_trash_size">کوڑے دان کے سائز کو اپ ڈیٹ کرنے میں ناکام: %1$s</string>
     <string name="no_cleaning_options_selected">براہ کرم آگے بڑھنے کے لئے ترتیبات میں اپنی صفائی کی ترجیحات کا انتخاب کریں۔</string>
     <string name="cleaning_in_progress">صفائی جاری ہے</string>
-    <string name="cleanup_progress">%1$d/%2$d فائلیں صاف ہوئیں</string>
+    <plurals name="cleanup_progress">
+        <item quantity="one">%1$d/%2$d فائل صاف ہوئی</item>
+        <item quantity="other">%1$d/%2$d فائلیں صاف ہوئیں</item>
+    </plurals>
     <string name="cleanup_finished">صفائی مکمل</string>
     <string name="cleanup_failed">صفائی ناکام</string>
     <string name="cleanup_failed_details">کچھ فائلیں حذف نہیں ہو سکیں</string>
     <string name="cleanup_cancelled">صفائی منسوخ کی گئی</string>
-    <string name="cleanup_partial">%1$d فائلیں حذف ہوئیں، %2$d ناکام ہوئیں</string>
+    <plurals name="cleanup_partial">
+        <item quantity="one">%1$d فائل حذف ہوئی، %2$d ناکام ہوئیں</item>
+        <item quantity="other">%1$d فائلیں حذف ہوئیں، %2$d ناکام ہوئیں</item>
+    </plurals>
     <plurals name="current_streak_label">
         <item quantity="one">موجودہ سلسلہ: مسلسل %1$d دن</item>
         <item quantity="other">موجودہ سلسلہ: مسلسل %1$d دن</item>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -394,12 +394,18 @@
     <string name="failed_to_update_trash_size">Không cập nhật kích thước rác: %1$s</string>
     <string name="no_cleaning_options_selected">Vui lòng chọn tùy chọn làm sạch của bạn trong cài đặt để tiếp tục.</string>
     <string name="cleaning_in_progress">Đang dọn dẹp</string>
-    <string name="cleanup_progress">%1$d/%2$d tệp đã được dọn</string>
+    <plurals name="cleanup_progress">
+        <item quantity="one">%1$d/%2$d tệp đã được dọn</item>
+        <item quantity="other">%1$d/%2$d tệp đã được dọn</item>
+    </plurals>
     <string name="cleanup_finished">Dọn dẹp xong</string>
     <string name="cleanup_failed">Dọn dẹp thất bại</string>
     <string name="cleanup_failed_details">Không thể xóa một số tệp</string>
     <string name="cleanup_cancelled">Đã hủy dọn dẹp</string>
-    <string name="cleanup_partial">%1$d tệp đã xóa, %2$d thất bại</string>
+    <plurals name="cleanup_partial">
+        <item quantity="one">%1$d tệp đã xóa, %2$d thất bại</item>
+        <item quantity="other">%1$d tệp đã xóa, %2$d thất bại</item>
+    </plurals>
     <plurals name="current_streak_label">
         <item quantity="other">Chuỗi hiện tại: %1$d ngày liên tiếp</item>
     </plurals>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -394,12 +394,18 @@
     <string name="failed_to_update_trash_size">更新垃圾桶大小失敗：%1$s</string>
     <string name="no_cleaning_options_selected">請在設定中選擇您的清理偏好以繼續。</string>
     <string name="cleaning_in_progress">正在清理中</string>
-    <string name="cleanup_progress">已清理 %1$d/%2$d 個檔案</string>
+    <plurals name="cleanup_progress">
+        <item quantity="one">已清理 %1$d/%2$d 個檔案</item>
+        <item quantity="other">已清理 %1$d/%2$d 個檔案</item>
+    </plurals>
     <string name="cleanup_finished">清理完成</string>
     <string name="cleanup_failed">清理失敗</string>
     <string name="cleanup_failed_details">部分檔案無法刪除</string>
     <string name="cleanup_cancelled">清理已取消</string>
-    <string name="cleanup_partial">已刪除 %1$d 個檔案，%2$d 個失敗</string>
+    <plurals name="cleanup_partial">
+        <item quantity="one">已刪除 %1$d 個檔案，%2$d 個失敗</item>
+        <item quantity="other">已刪除 %1$d 個檔案，%2$d 個失敗</item>
+    </plurals>
     <plurals name="current_streak_label">
         <item quantity="other">目前連續天數：%1$d 天</item>
     </plurals>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -407,10 +407,16 @@
     <string name="failed_to_update_trash_size">Failed to update trash size: %1$s</string>
     <string name="no_cleaning_options_selected">Please choose your cleaning preferences in settings to proceed.</string>
     <string name="cleaning_in_progress">Cleaning in progress</string>
-    <string name="cleanup_progress">%1$d/%2$d files cleaned</string>
+    <plurals name="cleanup_progress">
+        <item quantity="one">%1$d/%2$d file cleaned</item>
+        <item quantity="other">%1$d/%2$d files cleaned</item>
+    </plurals>
     <string name="cleanup_finished">Cleanup finished</string>
     <string name="cleanup_failed">Cleanup failed</string>
     <string name="cleanup_failed_details">Some files could not be deleted</string>
     <string name="cleanup_cancelled">Cleanup cancelled</string>
-    <string name="cleanup_partial">%1$d files deleted, %2$d failed</string>
+    <plurals name="cleanup_partial">
+        <item quantity="one">%1$d file deleted, %2$d failed</item>
+        <item quantity="other">%1$d files deleted, %2$d failed</item>
+    </plurals>
 </resources>


### PR DESCRIPTION
## Summary
- Use plural resources for `cleanup_partial` across all translations
- Update view models and worker code to build partial cleanup messages with `getQuantityString`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68999ffa61a8832d974ca41621e5813b