### PR TITLE
Use safe call when selecting image

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/images/compressor/ui/ImageOptimizerActivity.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/images/compressor/ui/ImageOptimizerActivity.kt
@@ -15,10 +15,8 @@ class ImageOptimizerActivity : BaseCleanupActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         selectedImageUriString = intent.getStringExtra("selectedImageUri")
-        if (!selectedImageUriString.isNullOrEmpty()) {
-            lifecycleScope.launch {
-                viewModel.onImageSelected(selectedImageUriString!!.toUri())
-            }
+        selectedImageUriString?.let { uri ->
+            lifecycleScope.launch { viewModel.onImageSelected(uri.toUri()) }
         }
         super.onCreate(savedInstanceState)
     }


### PR DESCRIPTION
## Summary
- handle selected image URI with a safe call and `let`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899a9b3c3cc832d9712405a3caac3d5