### PR TITLE
Refactor text preview snippet handling

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/utils/helpers/FilePreviewHelper.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/utils/helpers/FilePreviewHelper.kt
@@ -507,21 +507,19 @@ object FilePreviewHelper {
                 val snippet by produceState<String?>(initialValue = null, file.path) {
                     value = loadTextSnippet(file)
                 }
-                if (snippet != null) {
+                snippet?.let {
                     Text(
-                        text = snippet!!,
+                        text = it,
                         style = MaterialTheme.typography.labelSmall,
                         maxLines = 3,
                         overflow = TextOverflow.Ellipsis,
                         modifier = modifier
                     )
-                } else {
-                    Icon(
-                        painter = painterResource(id = R.drawable.ic_unknown_document),
-                        contentDescription = null,
-                        modifier = modifier.size(24.dp)
-                    )
-                }
+                } ?: Icon(
+                    painter = painterResource(id = R.drawable.ic_unknown_document),
+                    contentDescription = null,
+                    modifier = modifier.size(24.dp)
+                )
             }
 
             PreviewType.Archive -> {


### PR DESCRIPTION
## Summary
- Avoid force-unwrapping text preview snippet in `FilePreviewHelper`
- Rely on safe-cast and `let` to render the snippet when available

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899ad30de40832dafbaab42eaa63cdd