### PR TITLE
Fix WhatsApp media root path

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/utils/helpers/WhatsAppUtils.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/utils/helpers/WhatsAppUtils.kt
@@ -1,6 +1,7 @@
 package com.d4rk.cleaner.app.clean.scanner.utils.helpers
 
 import android.content.Context
+import android.os.Environment
 import com.d4rk.cleaner.app.clean.whatsapp.utils.constants.WhatsAppMediaConstants
 import java.io.File
 
@@ -14,7 +15,7 @@ import java.io.File
  * media is not accessible on the device.
  */
 fun getWhatsAppMediaDirs(context: Context): File? {
-    val root = context.getExternalFilesDir(null)?.parentFile?.parentFile?.parentFile ?: return null
+    val root = Environment.getExternalStorageDirectory()
     val legacy = File(root, "WhatsApp/Media")
     if (legacy.exists()) return legacy
     val scoped = File(root, "Android/media/com.whatsapp/WhatsApp/Media")


### PR DESCRIPTION
## Summary
- Resolve WhatsApp media scanning root to `/storage/emulated/0`
- Ensure both legacy and scoped WhatsApp media directories are checked

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a237c3444832d91740cb833887a3c