### PR TITLE
Extend WhatsApp variant detection

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
@@ -730,9 +730,17 @@ class ScannerViewModel(
 
     private fun checkWhatsAppInstalled() {
         launch(context = dispatchers.io) {
-            _isWhatsAppInstalled.value = runCatching {
-                application.packageManager.getPackageInfo("com.whatsapp", 0)
-            }.isSuccess
+            val pm = application.packageManager
+            val knownPackages = listOf("com.whatsapp", "com.whatsapp.w4b")
+            var installed = knownPackages.any { pkg ->
+                runCatching { pm.getPackageInfo(pkg, 0) }.isSuccess
+            }
+            if (!installed) {
+                @Suppress("DEPRECATION")
+                val packages = runCatching { pm.getInstalledPackages(0) }.getOrNull()
+                installed = packages?.any { it.packageName.startsWith("com.whatsapp") } == true
+            }
+            _isWhatsAppInstalled.value = installed
         }
     }
 

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/utils/helpers/WhatsAppUtils.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/utils/helpers/WhatsAppUtils.kt
@@ -15,11 +15,31 @@ import java.io.File
  * media is not accessible on the device.
  */
 fun getWhatsAppMediaDirs(context: Context): File? {
-    val root = Environment.getExternalStorageDirectory()
-    val legacy = File(root, "WhatsApp/Media")
-    if (legacy.exists()) return legacy
-    val scoped = File(root, "Android/media/com.whatsapp/WhatsApp/Media")
-    return scoped.takeIf { it.exists() }
+    val roots = mutableListOf<File>()
+    roots += Environment.getExternalStorageDirectory()
+    context.getExternalFilesDir(null)?.parentFile?.parentFile?.parentFile?.let { roots += it }
+
+    roots.distinct().forEach { root ->
+        // Check legacy top-level directories like "WhatsApp" and "WhatsApp Business"
+        listOf("WhatsApp", "WhatsApp Business").forEach { name ->
+            val legacy = File(root, "$name/Media")
+            if (legacy.exists()) return legacy
+        }
+
+        // Scan scoped storage packages that start with "com.whatsapp"
+        val mediaRoot = File(root, "Android/media")
+        mediaRoot.listFiles()?.forEach { pkgDir ->
+            if (pkgDir.name.startsWith("com.whatsapp")) {
+                pkgDir.listFiles()?.forEach { waDir ->
+                    if (waDir.isDirectory && waDir.name.startsWith("WhatsApp")) {
+                        val media = File(waDir, "Media")
+                        if (media.exists()) return media
+                    }
+                }
+            }
+        }
+    }
+    return null
 }
 
 /**

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/data/WhatsAppCleanerRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/data/WhatsAppCleanerRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.d4rk.cleaner.app.clean.whatsapp.summary.data
 
 import android.app.Application
+import android.os.Environment
 import android.text.format.Formatter
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.model.DeleteResult
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.model.DirectorySummary
@@ -15,19 +16,37 @@ import java.io.File
 class WhatsAppCleanerRepositoryImpl(private val application: Application) :
     WhatsAppCleanerRepository {
     /**
-     * Locate the base WhatsApp media directory. Returns `null` when neither the
-     * legacy nor the scoped-storage path exists, indicating that WhatsApp media
-     * is not available on the device.
+     * Locate the base WhatsApp media directory. Returns `null` when no known
+     * directories are found, indicating that WhatsApp media is not available on
+     * the device. Both the legacy and scoped-storage locations for official,
+     * business, and OEM dual-app variants are checked.
      */
     private fun getWhatsAppMediaDir(): File? {
-        val root = application.getExternalFilesDir(null)?.parentFile?.parentFile?.parentFile ?: return null
-        val scoped = File(root, "Android/media/com.whatsapp/WhatsApp/Media")
-        val legacy = File(root, "WhatsApp/Media")
-        return when {
-            scoped.exists() -> scoped
-            legacy.exists() -> legacy
-            else -> null
+        val roots = mutableListOf<File>()
+        application.getExternalFilesDir(null)?.parentFile?.parentFile?.parentFile?.let { roots += it }
+        roots += Environment.getExternalStorageDirectory()
+
+        roots.distinct().forEach { root ->
+            // Legacy top-level directories
+            listOf("WhatsApp", "WhatsApp Business").forEach { name ->
+                val legacy = File(root, "$name/Media")
+                if (legacy.exists()) return legacy
+            }
+
+            // Scoped storage packages that start with "com.whatsapp"
+            val mediaRoot = File(root, "Android/media")
+            mediaRoot.listFiles()?.forEach { pkgDir ->
+                if (pkgDir.name.startsWith("com.whatsapp")) {
+                    pkgDir.listFiles()?.forEach { waDir ->
+                        if (waDir.isDirectory && waDir.name.startsWith("WhatsApp")) {
+                            val media = File(waDir, "Media")
+                            if (media.exists()) return media
+                        }
+                    }
+                }
+            }
         }
+        return null
     }
 
     override suspend fun getMediaSummary(): WhatsAppMediaSummary = withContext(Dispatchers.IO) {


### PR DESCRIPTION
## Summary
- detect WhatsApp installations for business and OEM dual-app variants
- search alternative base folders for WhatsApp media
- update repository helpers to resolve variant media directories

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a26638b6c832db559c21fdb3a34cf