### PR TITLE
Replace println with Log and update permission check

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/AnalyzeScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/AnalyzeScreen.kt
@@ -36,9 +36,10 @@ import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.FileEntry
 import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.UiScannerModel
 import com.d4rk.cleaner.app.clean.scanner.ui.ScannerViewModel
 import com.d4rk.cleaner.app.clean.scanner.ui.components.TwoRowButtons
+import com.d4rk.cleaner.core.utils.helpers.LogHelper
 import kotlinx.coroutines.CoroutineScope
 
-private const val TAG = "AnalyzeScreen"
+private const val TAG = LogHelper.ANALYZE_SCREEN
 
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
@@ -69,10 +70,15 @@ fun AnalyzeScreen(
             when (data.analyzeState.state) {
 
                 CleaningState.Analyzing -> {
+                    Log.d(TAG, "Analyzing files")
                     LoadingScreen()
                 }
 
                 CleaningState.Cleaning -> {
+                    Log.d(
+                        TAG,
+                        "Cleaning: cleaned=${data.analyzeState.cleanedFilesCount} total=${data.analyzeState.totalFilesToClean}"
+                    )
                     CleaningAnimationScreen(
                         cleaned = data.analyzeState.cleanedFilesCount,
                         total = data.analyzeState.totalFilesToClean,
@@ -80,6 +86,7 @@ fun AnalyzeScreen(
                 }
 
                 CleaningState.ReadyToClean -> {
+                    Log.d(TAG, "ReadyToClean: groups=${groupedFiles.size}")
                     if (groupedFiles.isNotEmpty()) {
                         TabsContent(
                             groupedFiles = groupedFiles,
@@ -89,22 +96,27 @@ fun AnalyzeScreen(
                             data = data,
                         )
                     } else {
+                        Log.d(TAG, "No files found")
                         NoFilesFoundScreen(viewModel = viewModel)
                     }
                 }
 
                 CleaningState.Result -> {
+                    Log.d(TAG, "Showing results")
                     NoFilesFoundScreen(viewModel = viewModel)
                 }
 
                 CleaningState.Error -> {
+                    Log.e(TAG, "Error state encountered")
                     ErrorScreen(onRetry = {
                         viewModel.resetAfterError()
                         viewModel.onEvent(ScannerEvent.AnalyzeFiles)
                     })
                 }
 
-                CleaningState.Idle -> {}
+                CleaningState.Idle -> {
+                    Log.d(TAG, "Idle state")
+                }
             }
         }
         if (groupedFiles.isNotEmpty() && data.analyzeState.state == CleaningState.ReadyToClean) {

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/AnalyzeScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/AnalyzeScreen.kt
@@ -1,5 +1,6 @@
 package com.d4rk.cleaner.app.clean.analyze.ui
 
+import android.util.Log
 import android.view.View
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.animateContentSize
@@ -37,6 +38,8 @@ import com.d4rk.cleaner.app.clean.scanner.ui.ScannerViewModel
 import com.d4rk.cleaner.app.clean.scanner.ui.components.TwoRowButtons
 import kotlinx.coroutines.CoroutineScope
 
+private const val TAG = "AnalyzeScreen"
+
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
 fun AnalyzeScreen(
@@ -62,7 +65,7 @@ fun AnalyzeScreen(
                 .weight(weight = 1f)
                 .fillMaxWidth(),
         ) {
-            println(message = "The state of the screen is ${data.analyzeState.state}")
+            Log.d(TAG, "The state of the screen is ${data.analyzeState.state}")
             when (data.analyzeState.state) {
 
                 CleaningState.Analyzing -> {

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/domain/usecases/GetDuplicateContactsUseCase.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/domain/usecases/GetDuplicateContactsUseCase.kt
@@ -6,10 +6,11 @@ import com.d4rk.cleaner.app.clean.contacts.data.ContactsRepository
 import com.d4rk.cleaner.app.clean.contacts.domain.data.model.RawContactInfo
 import com.d4rk.cleaner.core.domain.model.network.Errors
 import com.d4rk.cleaner.core.utils.extensions.toError
+import com.d4rk.cleaner.core.utils.helpers.LogHelper
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
-private const val TAG = "GetDuplicateContactsUseCase"
+private const val TAG = LogHelper.GET_DUPLICATE_CONTACTS_USE_CASE
 
 class GetDuplicateContactsUseCase(private val repository: ContactsRepository) {
     operator fun invoke(): Flow<DataState<List<List<RawContactInfo>>, Errors>> = flow {

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/domain/usecases/GetDuplicateContactsUseCase.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/domain/usecases/GetDuplicateContactsUseCase.kt
@@ -1,5 +1,6 @@
 package com.d4rk.cleaner.app.clean.contacts.domain.usecases
 
+import android.util.Log
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.cleaner.app.clean.contacts.data.ContactsRepository
 import com.d4rk.cleaner.app.clean.contacts.domain.data.model.RawContactInfo
@@ -8,13 +9,15 @@ import com.d4rk.cleaner.core.utils.extensions.toError
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
+private const val TAG = "GetDuplicateContactsUseCase"
+
 class GetDuplicateContactsUseCase(private val repository: ContactsRepository) {
     operator fun invoke(): Flow<DataState<List<List<RawContactInfo>>, Errors>> = flow {
         emit(DataState.Loading())
         runCatching { repository.findDuplicates() }
             .onSuccess { emit(DataState.Success(it)) }
             .onFailure {
-                println(it)
+                Log.e(TAG, "Error fetching duplicate contacts", it)
                 emit(DataState.Error(error = it.toError()))
             }
     }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/ui/ContactsCleanerViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/ui/ContactsCleanerViewModel.kt
@@ -1,5 +1,6 @@
 package com.d4rk.cleaner.app.clean.contacts.ui
 
+import android.util.Log
 import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
@@ -28,6 +29,10 @@ class ContactsCleanerViewModel(
 ) : ScreenViewModel<UiContactsCleanerModel, ContactsCleanerEvent, ContactsCleanerAction>(
     initialState = UiStateScreen(data = UiContactsCleanerModel())
 ) {
+
+    companion object {
+        private const val TAG = "ContactsCleanerViewModel"
+    }
 
     init {
         onEvent(ContactsCleanerEvent.LoadDuplicates)
@@ -59,11 +64,9 @@ class ContactsCleanerViewModel(
             getDuplicatesUseCase().collectLatest { result ->
                 _uiState.update { current ->
 
-                    println("result: $result")
-
-
-                    println("error: ${(result as? DataState.Error)?.error}")
-                    println("message error: ${current.errors}")
+                    Log.d(TAG, "result: $result")
+                    Log.d(TAG, "error: ${(result as? DataState.Error)?.error}")
+                    Log.d(TAG, "message error: ${current.errors}")
 
 
                     when (result) {

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/ui/ContactsCleanerViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/ui/ContactsCleanerViewModel.kt
@@ -17,6 +17,7 @@ import com.d4rk.cleaner.app.clean.contacts.domain.usecases.DeleteOlderContactsUs
 import com.d4rk.cleaner.app.clean.contacts.domain.usecases.GetDuplicateContactsUseCase
 import com.d4rk.cleaner.app.clean.contacts.domain.usecases.MergeContactsUseCase
 import com.d4rk.cleaner.core.utils.extensions.asUiText
+import com.d4rk.cleaner.core.utils.helpers.LogHelper
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 
@@ -31,7 +32,7 @@ class ContactsCleanerViewModel(
 ) {
 
     companion object {
-        private const val TAG = "ContactsCleanerViewModel"
+        private const val TAG = LogHelper.CONTACTS_CLEANER_VIEW_MODEL
     }
 
     init {

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/dashboard/ui/ScannerDashboardScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/dashboard/ui/ScannerDashboardScreen.kt
@@ -54,6 +54,7 @@ import com.d4rk.cleaner.app.clean.dashboard.ui.components.DashboardActionCard
 import com.d4rk.cleaner.app.clean.whatsapp.summary.ui.WhatsAppCleanerActivity
 import com.d4rk.cleaner.app.images.picker.ui.ImagePickerActivity
 import com.d4rk.cleaner.core.data.datastore.DataStore
+import com.d4rk.cleaner.core.utils.helpers.LogHelper
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
 import org.koin.compose.koinInject
@@ -81,7 +82,7 @@ private sealed interface HomeItem {
     data class Ad(val slot: AdSlot) : HomeItem
 }
 
-private const val TAG = "ScannerDashboardScreen"
+private const val TAG = LogHelper.SCANNER_DASHBOARD_SCREEN
 
 @Composable
 fun ScannerDashboardScreen(

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/largefiles/ui/LargeFilesScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/largefiles/ui/LargeFilesScreen.kt
@@ -1,6 +1,7 @@
 package com.d4rk.cleaner.app.clean.largefiles.ui
 
 import android.view.View
+import android.util.Log
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -30,6 +31,7 @@ import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.CleaningState
 import org.koin.compose.viewmodel.koinViewModel
 import java.io.File
 
+private const val TAG = "LargeFilesScreen"
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LargeFilesScreen(activity: LargeFilesActivity) {
@@ -47,15 +49,15 @@ fun LargeFilesScreen(activity: LargeFilesActivity) {
                     CleaningAnimationScreen()
                 } else {
                     LoadingScreen()
-                    println("LoadingScreen")
+                    Log.d(TAG, "LoadingScreen")
                 }
             },
             onEmpty = {
-                println("onEmpty")
+                Log.d(TAG, "onEmpty")
                 NoDataScreen(textMessage = R.string.no_large_files, icon = Icons.Outlined.Folder)
             },
             onSuccess = { data: UiLargeFilesModel ->
-                println("onSuccess")
+                Log.d(TAG, "onSuccess")
                 ConstraintLayout(
                     modifier = Modifier
                         .padding(padding)

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/largefiles/ui/LargeFilesScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/largefiles/ui/LargeFilesScreen.kt
@@ -28,10 +28,11 @@ import com.d4rk.cleaner.app.clean.analyze.ui.components.FilesByDateSection
 import com.d4rk.cleaner.app.clean.largefiles.domain.actions.LargeFilesEvent
 import com.d4rk.cleaner.app.clean.largefiles.domain.data.model.ui.UiLargeFilesModel
 import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.CleaningState
+import com.d4rk.cleaner.core.utils.helpers.LogHelper
 import org.koin.compose.viewmodel.koinViewModel
 import java.io.File
 
-private const val TAG = "LargeFilesScreen"
+private const val TAG = LogHelper.LARGE_FILES_SCREEN
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LargeFilesScreen(activity: LargeFilesActivity) {

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/work/FileCleanupWorker.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/work/FileCleanupWorker.kt
@@ -6,9 +6,9 @@ import android.app.NotificationManager
 import android.content.Context
 import android.os.Build
 import android.util.Log
-import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
 import androidx.work.CoroutineWorker
 import androidx.work.Data
 import androidx.work.WorkerParameters
@@ -50,11 +50,11 @@ class FileCleanupWorker(
         }
         val action = inputData.getString(KEY_ACTION) ?: ACTION_DELETE
         val paths = rawPaths.toList()
-        println("FileCleanupWorker ---> Received paths: $paths")
+        Log.d(TAG, "Received paths: $paths")
         val files = mutableListOf<File>()
         var hasNonProtectedPath = false
         for (path in paths) {
-            println("FileCleanupWorker ---> Checking path: $path")
+            Log.d(TAG, "Checking path: $path")
             val file = File(path)
             if (file.isProtectedAndroidDir()) {
                 Log.i(TAG, "Skipping protected path: ${file.absolutePath}")
@@ -64,11 +64,11 @@ class FileCleanupWorker(
             val exists = file.exists()
             val isFile = file.isFile
             val isDirectory = file.isDirectory
-            println("FileCleanupWorker ---> File exists: $exists isFile: $isFile isDirectory: $isDirectory")
+            Log.d(TAG, "File exists: $exists isFile: $isFile isDirectory: $isDirectory")
             if (exists) {
-                println("FileCleanupWorker ---> canRead: ${file.canRead()} canWrite: ${file.canWrite()}")
+                Log.d(TAG, "canRead: ${file.canRead()} canWrite: ${file.canWrite()}")
                 if (isDirectory) {
-                    println("FileCleanupWorker ---> directory children: ${file.listFiles()?.size ?: 0}")
+                    Log.d(TAG, "directory children: ${file.listFiles()?.size ?: 0}")
                 }
                 files += file
             }
@@ -114,7 +114,7 @@ class FileCleanupWorker(
         setProgress(workDataOf(KEY_PROGRESS_CURRENT to processed, KEY_PROGRESS_TOTAL to total))
 
         val hasPermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            ActivityCompat.checkSelfPermission(
+            ContextCompat.checkSelfPermission(
                 applicationContext,
                 Manifest.permission.POST_NOTIFICATIONS,
             ) == android.content.pm.PackageManager.PERMISSION_GRANTED
@@ -145,7 +145,7 @@ class FileCleanupWorker(
                 return Result.failure()
             }
 
-            println("FileCleanupWorker ---> Attempting to $action: ${file.absolutePath}")
+            Log.d(TAG, "Attempting to $action: ${file.absolutePath}")
             when (val res = performAction(action, listOf(file))) {
                 is DataState.Error -> {
                     failedPaths += file.absolutePath
@@ -153,12 +153,12 @@ class FileCleanupWorker(
                         is Errors.Custom -> err.message
                         else -> err.toString()
                     }
-                    println("FileCleanupWorker ---> ERROR deleting ${file.absolutePath} → reason = $reason")
+                    Log.e(TAG, "Error deleting ${file.absolutePath} → reason = $reason")
                     Log.w(TAG, "Failed to process ${file.absolutePath}: $reason")
                 }
                 else -> {
                     successCount++
-                    println("FileCleanupWorker ---> Deleted: ${file.absolutePath} → result = success")
+                    Log.i(TAG, "Deleted: ${file.absolutePath} → result = success")
                 }
             }
             processed++
@@ -193,7 +193,7 @@ class FileCleanupWorker(
         builder.setProgress(0, 0, false)
 
         val failedCount = failedPaths.size
-        println("FileCleanupWorker ---> Deleted $successCount, failed $failedCount")
+        Log.i(TAG, "Deleted $successCount, failed $failedCount")
         val resultData = Data.Builder().apply {
             if (failedPaths.isNotEmpty()) {
                 putStringArray(KEY_FAILED_PATHS, failedPaths.toTypedArray())

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/work/FileCleanupWorker.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/work/FileCleanupWorker.kt
@@ -20,6 +20,7 @@ import com.d4rk.cleaner.app.clean.scanner.domain.usecases.DeleteFilesUseCase
 import com.d4rk.cleaner.core.domain.model.network.Errors
 import com.d4rk.cleaner.core.utils.helpers.CleaningEventBus
 import com.d4rk.cleaner.core.utils.helpers.isProtectedAndroidDir
+import com.d4rk.cleaner.core.utils.helpers.LogHelper
 import com.google.android.material.color.MaterialColors
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -286,6 +287,6 @@ class FileCleanupWorker(
         const val MAX_PATHS_PER_WORKER = 100
         private const val NOTIFICATION_ID = 2001
         private const val NOTIFICATION_CHANNEL = "file_cleanup"
-        private const val TAG = "FileCleanupWorker"
+        private const val TAG = LogHelper.FILE_CLEANUP_WORKER
     }
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/LogHelper.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/LogHelper.kt
@@ -1,0 +1,10 @@
+package com.d4rk.cleaner.core.utils.helpers
+
+object LogHelper {
+    const val CONTACTS_CLEANER_VIEW_MODEL = "ContactsCleanerViewModel"
+    const val GET_DUPLICATE_CONTACTS_USE_CASE = "GetDuplicateContactsUseCase"
+    const val ANALYZE_SCREEN = "AnalyzeScreen"
+    const val SCANNER_DASHBOARD_SCREEN = "ScannerDashboardScreen"
+    const val LARGE_FILES_SCREEN = "LargeFilesScreen"
+    const val FILE_CLEANUP_WORKER = "FileCleanupWorker"
+}


### PR DESCRIPTION
## Summary
- replace println debug calls with structured Log usage
- use `ContextCompat.checkSelfPermission` in `FileCleanupWorker`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b8c0b81c0832db5abd2a064c49721