### PR TITLE
feat: add share options for app manager

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/apps/manager/data/AppPackageManagerImpl.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/apps/manager/data/AppPackageManagerImpl.kt
@@ -56,7 +56,7 @@ class AppPackageManagerImpl(private val application: Application) : ApkInstaller
             )
             shareIntent.putExtra(Intent.EXTRA_STREAM, contentUri)
             shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-            shareIntent
+            Intent.createChooser(shareIntent, null)
         }.onSuccess { intent: Intent ->
             emit(value = DataState.Success(data = intent))
         }.onFailure { throwable ->
@@ -72,7 +72,7 @@ class AppPackageManagerImpl(private val application: Application) : ApkInstaller
             val playStoreLink = "https://play.google.com/store/apps/details?id=$packageName"
             val shareMessage = "Check out this app: ${getAppName(packageName)}\n$playStoreLink"
             shareIntent.putExtra(Intent.EXTRA_TEXT, shareMessage)
-            shareIntent
+            Intent.createChooser(shareIntent, null)
         }.onSuccess { intent: Intent ->
             emit(value = DataState.Success(data = intent))
         }.onFailure { throwable: Throwable ->

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/apps/manager/domain/actions/AppManagerEvent.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/apps/manager/domain/actions/AppManagerEvent.kt
@@ -6,5 +6,8 @@ import com.d4rk.cleaner.app.apps.manager.domain.data.model.AppManagerItem
 sealed class AppManagerEvent : UiEvent {
     object LoadAppData : AppManagerEvent()
     data class ShareItem(val item: AppManagerItem) : AppManagerEvent()
+    data object ShareStoreLink : AppManagerEvent()
+    data object ShareApkFile : AppManagerEvent()
+    data object DismissShareOptions : AppManagerEvent()
     data object DismissSnackbar : AppManagerEvent()
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/apps/manager/ui/AppManagerScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/apps/manager/ui/AppManagerScreen.kt
@@ -30,7 +30,12 @@ import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.TabRowDefaults
 import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.Text
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -40,11 +45,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.clickable
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Android
+import androidx.compose.material.icons.outlined.Link
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.digits.AnimatedDigit
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
@@ -75,12 +84,13 @@ object AppManagerBadgeTransitions {
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
+@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun AppManagerScreen(snackbarHostState: SnackbarHostState, paddingValues: PaddingValues) {
     val viewModel: AppManagerViewModel = koinViewModel()
     val context: Context = LocalContext.current
     val uiState: UiStateScreen<UiAppManagerModel> by viewModel.uiState.collectAsState()
+    val sharePackage by viewModel.sharePackage.collectAsState()
 
     LaunchedEffect(context) {
         if (!PermissionsHelper.hasUsageAccessPermissions(context)) {
@@ -109,6 +119,29 @@ fun AppManagerScreen(snackbarHostState: SnackbarHostState, paddingValues: Paddin
         snackbarHostState = snackbarHostState,
         getDismissEvent = { AppManagerEvent.DismissSnackbar },
         onEvent = { viewModel.onEvent(event = it) })
+
+    sharePackage?.let {
+        val sheetState = rememberModalBottomSheetState()
+        ModalBottomSheet(
+            onDismissRequest = { viewModel.onEvent(AppManagerEvent.DismissShareOptions) },
+            sheetState = sheetState,
+        ) {
+            ListItem(
+                headlineContent = { Text(text = stringResource(id = R.string.share_play_store_link)) },
+                leadingContent = { Icon(imageVector = Icons.Outlined.Link, contentDescription = null) },
+                modifier = Modifier.clickable {
+                    viewModel.onEvent(AppManagerEvent.ShareStoreLink)
+                },
+            )
+            ListItem(
+                headlineContent = { Text(text = stringResource(id = R.string.share_apk_file)) },
+                leadingContent = { Icon(imageVector = Icons.Outlined.Android, contentDescription = null) },
+                modifier = Modifier.clickable {
+                    viewModel.onEvent(AppManagerEvent.ShareApkFile)
+                },
+            )
+        }
+    }
 }
 
 @OptIn(ExperimentalFoundationApi::class)

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/apps/manager/ui/AppManagerViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/apps/manager/ui/AppManagerViewModel.kt
@@ -67,6 +67,9 @@ class AppManagerViewModel(
     private var pendingInstallPackage: String? = null
     private var loadJob: Job? = null
 
+    private val _sharePackage = MutableStateFlow<String?>(null)
+    val sharePackage = _sharePackage.asStateFlow()
+
     fun onSearchQueryChange(query: String) {
         _searchQuery.value = query
     }
@@ -132,6 +135,9 @@ class AppManagerViewModel(
         when (event) {
             AppManagerEvent.LoadAppData -> loadAppData()
             is AppManagerEvent.ShareItem -> handleShareItem(event.item)
+            AppManagerEvent.ShareStoreLink -> shareStoreLink()
+            AppManagerEvent.ShareApkFile -> shareAppApk()
+            AppManagerEvent.DismissShareOptions -> _sharePackage.value = null
             is AppManagerEvent.DismissSnackbar -> screenState.dismissSnackbar()
         }
     }
@@ -285,14 +291,14 @@ class AppManagerViewModel(
                         when (result) {
                             is DataState.Success -> sendAction(
                                 AppManagerAction.LaunchShareIntent(
-                                    result.data
-                                )
+                                    result.data,
+                                ),
                             )
 
                             is DataState.Error -> postSnackbar(
                                 message = UiTextHelper.StringResource(
-                                    R.string.share_apk_failed
-                                ), isError = true
+                                    R.string.share_apk_failed,
+                                ), isError = true,
                             )
 
                             else -> {}
@@ -301,24 +307,62 @@ class AppManagerViewModel(
                 }
 
                 is AppManagerItem.InstalledApp -> {
-                    shareAppUseCase(item.packageName).collectLatest { result ->
-                        when (result) {
-                            is DataState.Success -> sendAction(
-                                AppManagerAction.LaunchShareIntent(
-                                    result.data
-                                )
-                            )
-
-                            is DataState.Error -> postSnackbar(
-                                message = UiTextHelper.StringResource(
-                                    R.string.share_app_failed
-                                ), isError = true
-                            )
-
-                            else -> {}
-                        }
-                    }
+                    _sharePackage.value = item.packageName
                 }
+            }
+        }
+    }
+
+    private fun shareStoreLink() {
+        val packageName = _sharePackage.value ?: return
+        launch(dispatchers.io) {
+            shareAppUseCase(packageName).collectLatest { result ->
+                when (result) {
+                    is DataState.Success -> sendAction(
+                        AppManagerAction.LaunchShareIntent(result.data),
+                    )
+
+                    is DataState.Error -> postSnackbar(
+                        message = UiTextHelper.StringResource(
+                            R.string.share_app_failed,
+                        ), isError = true,
+                    )
+
+                    else -> {}
+                }
+                _sharePackage.value = null
+            }
+        }
+    }
+
+    private fun shareAppApk() {
+        val packageName = _sharePackage.value ?: return
+        launch(dispatchers.io) {
+            runCatching {
+                applicationContext.packageManager.getApplicationInfo(packageName, 0).publicSourceDir
+            }.onSuccess { apkPath ->
+                shareApkUseCase(apkPath).collectLatest { result ->
+                    when (result) {
+                        is DataState.Success -> sendAction(
+                            AppManagerAction.LaunchShareIntent(result.data),
+                        )
+
+                        is DataState.Error -> postSnackbar(
+                            message = UiTextHelper.StringResource(
+                                R.string.share_apk_failed,
+                            ), isError = true,
+                        )
+
+                        else -> {}
+                    }
+                    _sharePackage.value = null
+                }
+            }.onFailure {
+                _sharePackage.value = null
+                postSnackbar(
+                    message = UiTextHelper.StringResource(R.string.share_apk_failed),
+                    isError = true,
+                )
             }
         }
     }

--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -420,6 +420,8 @@
     <string name="failed_to_open_app_info">فشل فتح معلومات التطبيق: %1$s</string>
     <string name="share_apk_failed">فشل مشاركة ملف APK</string>
     <string name="share_app_failed">فشل مشاركة التطبيق</string>
+    <string name="share_play_store_link">مشاركة رابط متجر Play</string>
+    <string name="share_apk_file">مشاركة ملف APK</string>
     <string name="apk_installed_successfully">ملف APK اتثبت بنجاح!</string>
     <string name="failed_to_install_apk">فشل تثبيت ملف APK: %1$s</string>
     <string name="failed_to_uninstall_app">فشل إلغاء تثبيت التطبيق: %1$s</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -383,6 +383,8 @@
     <string name="failed_to_open_app_info">Неуспешно отваряне на информацията за приложението: %1$s</string>
     <string name="share_apk_failed">Неуспешно споделяне на APK</string>
     <string name="share_app_failed">Неуспешно споделяне на приложението</string>
+    <string name="share_play_store_link">Сподели връзката в Play Store</string>
+    <string name="share_apk_file">Сподели APK файла</string>
     <string name="apk_installed_successfully">APK файлът е инсталиран успешно!</string>
     <string name="failed_to_install_apk">Неуспешно инсталиране на APK: %1$s</string>
     <string name="failed_to_uninstall_app">Неуспешно деинсталиране на приложението: %1$s</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -383,6 +383,8 @@
     <string name="failed_to_open_app_info">অ্যাপের তথ্য খুলতে ব্যর্থ: %1$s</string>
     <string name="share_apk_failed">APK শেয়ার করতে ব্যর্থ</string>
     <string name="share_app_failed">অ্যাপ শেয়ার করতে ব্যর্থ</string>
+    <string name="share_play_store_link">প্লে স্টোর লিংক শেয়ার করুন</string>
+    <string name="share_apk_file">APK ফাইল শেয়ার করুন</string>
     <string name="apk_installed_successfully">APK সফলভাবে ইনস্টল হয়েছে!</string>
     <string name="failed_to_install_apk">APK ইনস্টল করতে ব্যর্থ: %1$s</string>
     <string name="failed_to_uninstall_app">অ্যাপ আনইনস্টল করতে ব্যর্থ: %1$s</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -384,6 +384,8 @@
     <string name="failed_to_open_app_info">App-Info konnte nicht geöffnet werden: %1$s</string>
     <string name="share_apk_failed">Teilen der APK fehlgeschlagen</string>
     <string name="share_app_failed">Teilen der App fehlgeschlagen</string>
+    <string name="share_play_store_link">Play-Store-Link teilen</string>
+    <string name="share_apk_file">APK-Datei teilen</string>
     <string name="apk_installed_successfully">APK erfolgreich installiert!</string>
     <string name="failed_to_install_apk">Installation der APK fehlgeschlagen: %1$s</string>
     <string name="failed_to_uninstall_app">Deinstallation der App fehlgeschlagen: %1$s</string>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -393,6 +393,8 @@
     <string name="failed_to_open_app_info">No se pudo abrir la información de la aplicación: %1$s</string>
     <string name="share_apk_failed">No se pudo compartir el APK</string>
     <string name="share_app_failed">No se pudo compartir la aplicación</string>
+    <string name="share_play_store_link">Compartir enlace de Play Store</string>
+    <string name="share_apk_file">Compartir archivo APK</string>
     <string name="apk_installed_successfully">¡APK instalado correctamente!</string>
     <string name="failed_to_install_apk">No se pudo instalar el APK: %1$s</string>
     <string name="failed_to_uninstall_app">No se pudo desinstalar la aplicación: %1$s</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -393,6 +393,8 @@
     <string name="failed_to_open_app_info">No se pudo abrir la información de la aplicación: %1$s</string>
     <string name="share_apk_failed">No se pudo compartir el APK</string>
     <string name="share_app_failed">No se pudo compartir la aplicación</string>
+    <string name="share_play_store_link">Compartir enlace de Play Store</string>
+    <string name="share_apk_file">Compartir archivo APK</string>
     <string name="apk_installed_successfully">¡APK instalado correctamente!</string>
     <string name="failed_to_install_apk">No se pudo instalar el APK: %1$s</string>
     <string name="failed_to_uninstall_app">No se pudo desinstalar la aplicación: %1$s</string>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -384,6 +384,8 @@
     <string name="failed_to_open_app_info">Nabigong buksan ang impormasyon ng app: %1$s</string>
     <string name="share_apk_failed">Nabigong ibahagi ang APK</string>
     <string name="share_app_failed">Nabigong ibahagi ang app</string>
+    <string name="share_play_store_link">Ibahagi ang Play Store link</string>
+    <string name="share_apk_file">Ibahagi ang APK file</string>
     <string name="apk_installed_successfully">Matagumpay na na-install ang APK!</string>
     <string name="failed_to_install_apk">Nabigong i-install ang APK: %1$s</string>
     <string name="failed_to_uninstall_app">Nabigong i-uninstall ang app: %1$s</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -394,6 +394,8 @@
     <string name="failed_to_open_app_info">Échec de l\'ouverture des infos de l\'application : %1$s</string>
     <string name="share_apk_failed">Échec du partage de l\'APK</string>
     <string name="share_app_failed">Échec du partage de l\'application</string>
+    <string name="share_play_store_link">Partager le lien Play Store</string>
+    <string name="share_apk_file">Partager le fichier APK</string>
     <string name="apk_installed_successfully">APK installé avec succès !</string>
     <string name="failed_to_install_apk">Échec de l\'installation de l\'APK : %1$s</string>
     <string name="failed_to_uninstall_app">Échec de la désinstallation de l\'application : %1$s</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -384,6 +384,8 @@
     <string name="failed_to_open_app_info">ऐप जानकारी खोलने में विफल: %1$s</string>
     <string name="share_apk_failed">एपीके साझा करने में विफल</string>
     <string name="share_app_failed">ऐप साझा करने में विफल</string>
+    <string name="share_play_store_link">प्ले स्टोर लिंक साझा करें</string>
+    <string name="share_apk_file">APK फ़ाइल साझा करें</string>
     <string name="apk_installed_successfully">एपीके सफलतापूर्वक इंस्टॉल हो गया!</string>
     <string name="failed_to_install_apk">एपीके इंस्टॉल करने में विफल: %1$s</string>
     <string name="failed_to_uninstall_app">ऐप अनइंस्टॉल करने में विफल: %1$s</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -384,6 +384,8 @@
     <string name="failed_to_open_app_info">Nem sikerült megnyitni az alkalmazásinformációt: %1$s</string>
     <string name="share_apk_failed">Nem sikerült megosztani az APK-t</string>
     <string name="share_app_failed">Nem sikerült megosztani az alkalmazást</string>
+    <string name="share_play_store_link">Play Áruház hivatkozás megosztása</string>
+    <string name="share_apk_file">APK fájl megosztása</string>
     <string name="apk_installed_successfully">Az APK sikeresen telepítve!</string>
     <string name="failed_to_install_apk">Nem sikerült telepíteni az APK-t: %1$s</string>
     <string name="failed_to_uninstall_app">Nem sikerült eltávolítani az alkalmazást: %1$s</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -375,6 +375,8 @@
     <string name="failed_to_open_app_info">Gagal membuka info aplikasi: %1$s</string>
     <string name="share_apk_failed">Gagal membagikan APK</string>
     <string name="share_app_failed">Gagal membagikan aplikasi</string>
+    <string name="share_play_store_link">Bagikan link Play Store</string>
+    <string name="share_apk_file">Bagikan file APK</string>
     <string name="apk_installed_successfully">APK berhasil diinstal!</string>
     <string name="failed_to_install_apk">Gagal menginstal APK: %1$s</string>
     <string name="failed_to_uninstall_app">Gagal mencopot pemasangan aplikasi: %1$s</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -393,6 +393,8 @@
     <string name="failed_to_open_app_info">Impossibile aprire info app: %1$s</string>
     <string name="share_apk_failed">Impossibile condividere l\'APK</string>
     <string name="share_app_failed">Impossibile condividere l\'app</string>
+    <string name="share_play_store_link">Condividi link del Play Store</string>
+    <string name="share_apk_file">Condividi file APK</string>
     <string name="apk_installed_successfully">APK installato con successo!</string>
     <string name="failed_to_install_apk">Impossibile installare l\'APK: %1$s</string>
     <string name="failed_to_uninstall_app">Impossibile disinstallare l\'app: %1$s</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -375,6 +375,8 @@
     <string name="failed_to_open_app_info">アプリ情報を開けませんでした: %1$s</string>
     <string name="share_apk_failed">APKの共有に失敗しました</string>
     <string name="share_app_failed">アプリの共有に失敗しました</string>
+    <string name="share_play_store_link">Play ストアのリンクを共有</string>
+    <string name="share_apk_file">APK ファイルを共有</string>
     <string name="apk_installed_successfully">APKが正常にインストールされました！</string>
     <string name="failed_to_install_apk">APKのインストールに失敗しました: %1$s</string>
     <string name="failed_to_uninstall_app">アプリのアンインストールに失敗しました: %1$s</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -375,6 +375,8 @@
     <string name="failed_to_open_app_info">앱 정보를 열지 못했습니다: %1$s</string>
     <string name="share_apk_failed">APK 공유 실패</string>
     <string name="share_app_failed">앱 공유 실패</string>
+    <string name="share_play_store_link">Play 스토어 링크 공유</string>
+    <string name="share_apk_file">APK 파일 공유</string>
     <string name="apk_installed_successfully">APK가 성공적으로 설치되었습니다!</string>
     <string name="failed_to_install_apk">APK 설치 실패: %1$s</string>
     <string name="failed_to_uninstall_app">앱 제거 실패: %1$s</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -402,6 +402,8 @@
     <string name="failed_to_open_app_info">Nie udało się otworzyć informacji o aplikacji: %1$s</string>
     <string name="share_apk_failed">Nie udało się udostępnić pliku APK</string>
     <string name="share_app_failed">Nie udało się udostępnić aplikacji</string>
+    <string name="share_play_store_link">Udostępnij link do Sklepu Play</string>
+    <string name="share_apk_file">Udostępnij plik APK</string>
     <string name="apk_installed_successfully">Plik APK został pomyślnie zainstalowany!</string>
     <string name="failed_to_install_apk">Nie udało się zainstalować pliku APK: %1$s</string>
     <string name="failed_to_uninstall_app">Nie udało się odinstalować aplikacji: %1$s</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -393,6 +393,8 @@
     <string name="failed_to_open_app_info">Falha ao abrir informações do aplicativo: %1$s</string>
     <string name="share_apk_failed">Falha ao compartilhar APK</string>
     <string name="share_app_failed">Falha ao compartilhar aplicativo</string>
+    <string name="share_play_store_link">Compartilhar link da Play Store</string>
+    <string name="share_apk_file">Compartilhar arquivo APK</string>
     <string name="apk_installed_successfully">APK instalado com sucesso!</string>
     <string name="failed_to_install_apk">Falha ao instalar APK: %1$s</string>
     <string name="failed_to_uninstall_app">Falha ao desinstalar aplicativo: %1$s</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -393,6 +393,8 @@
     <string name="failed_to_open_app_info">Nu s-au putut deschide informațiile aplicației: %1$s</string>
     <string name="share_apk_failed">Nu s-a putut partaja APK-ul</string>
     <string name="share_app_failed">Nu s-a putut partaja aplicația</string>
+    <string name="share_play_store_link">Partajează linkul Play Store</string>
+    <string name="share_apk_file">Partajează fișierul APK</string>
     <string name="apk_installed_successfully">APK instalat cu succes!</string>
     <string name="failed_to_install_apk">Nu s-a putut instala APK-ul: %1$s</string>
     <string name="failed_to_uninstall_app">Nu s-a putut dezinstala aplicația: %1$s</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -402,6 +402,8 @@
     <string name="failed_to_open_app_info">Не удалось открыть информацию о приложении: %1$s</string>
     <string name="share_apk_failed">Не удалось поделиться APK</string>
     <string name="share_app_failed">Не удалось поделиться приложением</string>
+    <string name="share_play_store_link">Поделиться ссылкой на Play Store</string>
+    <string name="share_apk_file">Поделиться файлом APK</string>
     <string name="apk_installed_successfully">APK успешно установлен!</string>
     <string name="failed_to_install_apk">Не удалось установить APK: %1$s</string>
     <string name="failed_to_uninstall_app">Не удалось удалить приложение: %1$s</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -384,6 +384,8 @@
     <string name="failed_to_open_app_info">Kunde inte öppna appinformation: %1$s</string>
     <string name="share_apk_failed">Kunde inte dela APK</string>
     <string name="share_app_failed">Kunde inte dela app</string>
+    <string name="share_play_store_link">Dela Play Store-länk</string>
+    <string name="share_apk_file">Dela APK-fil</string>
     <string name="apk_installed_successfully">APK installerades framgångsrikt!</string>
     <string name="failed_to_install_apk">Kunde inte installera APK: %1$s</string>
     <string name="failed_to_uninstall_app">Kunde inte avinstallera app: %1$s</string>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -375,6 +375,8 @@
     <string name="failed_to_open_app_info">ไม่สามารถเปิดข้อมูลแอปได้: %1$s</string>
     <string name="share_apk_failed">ไม่สามารถแชร์ APK ได้</string>
     <string name="share_app_failed">ไม่สามารถแชร์แอปได้</string>
+    <string name="share_play_store_link">แชร์ลิงก์ Play Store</string>
+    <string name="share_apk_file">แชร์ไฟล์ APK</string>
     <string name="apk_installed_successfully">ติดตั้ง APK สำเร็จแล้ว!</string>
     <string name="failed_to_install_apk">ติดตั้ง APK ไม่สำเร็จ: %1$s</string>
     <string name="failed_to_uninstall_app">ถอนการติดตั้งแอปไม่สำเร็จ: %1$s</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -384,6 +384,8 @@
     <string name="failed_to_open_app_info">Uygulama bilgisi açılamadı: %1$s</string>
     <string name="share_apk_failed">APK paylaşılamadı</string>
     <string name="share_app_failed">Uygulama paylaşılamadı</string>
+    <string name="share_play_store_link">Play Store bağlantısını paylaş</string>
+    <string name="share_apk_file">APK dosyasını paylaş</string>
     <string name="apk_installed_successfully">APK başarıyla yüklendi!</string>
     <string name="failed_to_install_apk">APK yüklenemedi: %1$s</string>
     <string name="failed_to_uninstall_app">Uygulama kaldırılamadı: %1$s</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -402,6 +402,8 @@
     <string name="failed_to_open_app_info">Не вдалося відкрити інформацію про додаток: %1$s</string>
     <string name="share_apk_failed">Не вдалося поділитися APK-файлом</string>
     <string name="share_app_failed">Не вдалося поділитися додатком</string>
+    <string name="share_play_store_link">Поділитися посиланням Play Store</string>
+    <string name="share_apk_file">Поділитися файлом APK</string>
     <string name="apk_installed_successfully">APK-файл успішно встановлено!</string>
     <string name="failed_to_install_apk">Не вдалося встановити APK: %1$s</string>
     <string name="failed_to_uninstall_app">Не вдалося видалити додаток: %1$s</string>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -384,6 +384,8 @@
     <string name="failed_to_open_app_info">ایپ کی معلومات کھولنے میں ناکام: %1$s</string>
     <string name="share_apk_failed">APK شیئر کرنے میں ناکام</string>
     <string name="share_app_failed">ایپ شیئر کرنے میں ناکام</string>
+    <string name="share_play_store_link">پلے اسٹور لنک شیئر کریں</string>
+    <string name="share_apk_file">APK فائل شیئر کریں</string>
     <string name="apk_installed_successfully">APK کامیابی سے انسٹال ہوگئی!</string>
     <string name="failed_to_install_apk">APK انسٹال کرنے میں ناکام: %1$s</string>
     <string name="failed_to_uninstall_app">ایپ ان انسٹال کرنے میں ناکام: %1$s</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -375,6 +375,8 @@
     <string name="failed_to_open_app_info">Không thể mở thông tin ứng dụng: %1$s</string>
     <string name="share_apk_failed">Không thể chia sẻ tệp APK</string>
     <string name="share_app_failed">Không thể chia sẻ ứng dụng</string>
+    <string name="share_play_store_link">Chia sẻ liên kết Play Store</string>
+    <string name="share_apk_file">Chia sẻ tệp APK</string>
     <string name="apk_installed_successfully">Đã cài đặt APK thành công!</string>
     <string name="failed_to_install_apk">Không thể cài đặt APK: %1$s</string>
     <string name="failed_to_uninstall_app">Không thể gỡ cài đặt ứng dụng: %1$s</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -375,6 +375,8 @@
     <string name="failed_to_open_app_info">無法開啟應用程式資訊：%1$s</string>
     <string name="share_apk_failed">無法分享 APK</string>
     <string name="share_app_failed">無法分享應用程式</string>
+    <string name="share_play_store_link">分享 Play 商店連結</string>
+    <string name="share_apk_file">分享 APK 檔案</string>
     <string name="apk_installed_successfully">APK 安裝成功！</string>
     <string name="failed_to_install_apk">無法安裝 APK：%1$s</string>
     <string name="failed_to_uninstall_app">無法解除安裝應用程式：%1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -389,6 +389,8 @@
     <string name="failed_to_open_app_info">Failed to open app info: %1$s</string>
     <string name="share_apk_failed">Failed to share APK</string>
     <string name="share_app_failed">Failed to share app</string>
+    <string name="share_play_store_link">Share Play Store link</string>
+    <string name="share_apk_file">Share APK file</string>
     <string name="apk_installed_successfully">APK installed successfully!</string>
     <string name="failed_to_install_apk">Failed to install APK: %1$s</string>
     <string name="failed_to_uninstall_app">Failed to uninstall app: %1$s</string>


### PR DESCRIPTION
## Summary
- add bottom sheet to choose sharing Play Store link or APK file
- route share actions through Android Sharesheet
- include strings for new share options

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cb78d0180832d9bd9ac2b15f8d39b