### PR TITLE
Enable APK sharing from absolute paths

### DIFF
--- a/app/src/main/res/xml/provider_paths.xml
+++ b/app/src/main/res/xml/provider_paths.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
+    <root-path
+        name="apk"
+        path="." />
     <external-path
         name="external_files"
         path="." />


### PR DESCRIPTION
## Summary
- allow FileProvider to expose files from any absolute path for APK sharing

## Testing
- `./gradlew build` *(fails: SDK location not found / missing Android SDK packages)*

------
https://chatgpt.com/codex/tasks/task_e_689cc11af63c832d9e4570a825a5967a