### PR TITLE
Return chooser intent from prepareShareIntent

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/apps/manager/data/AppPackageManagerImpl.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/apps/manager/data/AppPackageManagerImpl.kt
@@ -56,9 +56,10 @@ class AppPackageManagerImpl(private val application: Application) : ApkInstaller
             )
             shareIntent.putExtra(Intent.EXTRA_STREAM, contentUri)
             shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-            Intent.createChooser(shareIntent, null)
-        }.onSuccess { intent: Intent ->
-            emit(value = DataState.Success(data = intent))
+            val chooserIntent = Intent.createChooser(shareIntent, null)
+            chooserIntent
+        }.onSuccess { chooserIntent: Intent ->
+            emit(value = DataState.Success(data = chooserIntent))
         }.onFailure { throwable ->
             emit(value = DataState.Error(error = throwable.toError(default = Errors.UseCase.FAILED_TO_SHARE_APK)))
         }


### PR DESCRIPTION
## Summary
- capture chooser intent when sharing APKs
- emit chooser intent so caller can launch share dialog directly

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cc35b6348832db3365cc875eae3d0