### PR TITLE
Use labeled return in partialMd5 extension

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/extensions/FileExtensions.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/extensions/FileExtensions.kt
@@ -22,7 +22,7 @@ fun File.md5(): String? = runCatching {
 
 fun File.partialMd5(): String? = runCatching {
     if (length() <= PARTIAL_HASH_SIZE * 2) {
-        return md5()
+        return@runCatching md5()
     }
 
     val md = MessageDigest.getInstance("MD5")


### PR DESCRIPTION
## Summary
- ensure partialMd5 uses labeled return within runCatching to return a Result

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d7ffd64c0832dad417dabfcbc25f4