### PR TITLE
Manage StreakTracker lifecycle with app scope

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/Cleaner.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/Cleaner.kt
@@ -41,7 +41,7 @@ class Cleaner : BaseCoreManager(), SingletonImageLoader.Factory, DefaultLifecycl
 
     override fun onCreate() {
         initializeKoin(context = this)
-        StreakTracker.initialize()
+        StreakTracker.initialize(ProcessLifecycleOwner.get().lifecycleScope)
         SingletonImageLoader.setSafe { newImageLoader(this) }
         super<BaseCoreManager>.onCreate()
         sessionStartTime = System.currentTimeMillis()
@@ -57,6 +57,11 @@ class Cleaner : BaseCoreManager(), SingletonImageLoader.Factory, DefaultLifecycl
         }
         registerActivityLifecycleCallbacks(this)
         ProcessLifecycleOwner.get().lifecycle.addObserver(observer = this)
+    }
+
+    override fun onTerminate() {
+        StreakTracker.shutdown()
+        super<BaseCoreManager>.onTerminate()
     }
 
     override suspend fun onInitializeApp(): Unit = supervisorScope {

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/StreakTracker.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/StreakTracker.kt
@@ -5,22 +5,30 @@ import com.d4rk.cleaner.core.utils.constants.TimeConstants
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
 object StreakTracker : KoinComponent {
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private val dataStore: DataStore by inject()
+    private var scope: CoroutineScope? = null
 
+    fun initialize(externalScope: CoroutineScope? = null) {
+        if (scope != null) return
 
-    fun initialize() {
-        scope.launch {
+        scope = externalScope ?: CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        scope?.launch {
             CleaningEventBus.events.collect {
                 updateStreak()
             }
         }
+    }
+
+    fun shutdown() {
+        scope?.cancel()
+        scope = null
     }
 
     private suspend fun updateStreak() {


### PR DESCRIPTION
## Summary
- allow passing a CoroutineScope into StreakTracker and expose a shutdown() API
- initialize StreakTracker with the app process lifecycle scope and cancel on termination

## Testing
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d88489788832d98ca9c5b66ce20b4