### PR TITLE
Check auto clean frequency before scheduling work

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/auto/AutoCleanScheduler.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/auto/AutoCleanScheduler.kt
@@ -14,6 +14,11 @@ object AutoCleanScheduler {
 
     suspend fun schedule(context: Context, dataStore: DataStore) {
         val frequency = dataStore.autoCleanFrequencyDays.first()
+        if (frequency <= 0) {
+            cancel(context)
+            return
+        }
+
         val constraints = Constraints.Builder()
             .setRequiresBatteryNotLow(true)
             .build()


### PR DESCRIPTION
## Summary
- Skip auto-clean scheduling when frequency is zero or negative

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d992825a4832da85702a8e4c4ab7a