### PR TITLE
Hide WhatsApp details sort button when empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - **Minor**: Redesigned the streak card for better visualisation.
 - **Minor**: Redesigned the image optimizer for better management.
 - **Patch**: Various bug fixes and performance improvements to keep the app running smoothly.
+- **Patch**: Hide sort option on WhatsApp cleaner details when no media items are available.
 
 # Version 3.5.0:
 

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/WhatsAppDetailsScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/WhatsAppDetailsScreen.kt
@@ -145,11 +145,11 @@ fun DetailsScreen(
                 fromRight = true)
 
             AnimatedIconButtonDirection(
-                visible = true,
+                visible = hasFiles,
                 icon = Icons.AutoMirrored.Filled.Sort,
                 contentDescription = null,
                 onClick = {
-                    showSort = hasFiles
+                    showSort = true
                 },
                 durationMillis = 400,
                 fromRight = true)


### PR DESCRIPTION
## Summary
- hide sort option on WhatsApp details screen when no media items are present
- document change in changelog

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d9dd7cef0832da6ea4ba960b7fe62