### PR TITLE
Add animated empty state for WhatsApp details screen

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/WhatsAppDetailsScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/WhatsAppDetailsScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.material.icons.automirrored.filled.Sort
 import androidx.compose.material.icons.automirrored.filled.ViewList
 import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.outlined.Delete
-import androidx.compose.material.icons.outlined.FolderOff
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -60,7 +59,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.AnimatedIconB
 import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.IconButtonWithText
 import com.d4rk.android.libs.apptoolkit.core.ui.components.dialogs.BasicAlertDialog
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.LoadingScreen
-import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.NoDataScreen
+import com.d4rk.cleaner.app.clean.whatsapp.details.ui.components.states.WhatsAppDetailsEmptyState
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.ScreenStateHandler
 import com.d4rk.android.libs.apptoolkit.core.ui.components.navigation.LargeTopAppBarWithScaffold
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.ExtraSmallHorizontalSpacer
@@ -172,11 +171,7 @@ fun DetailsScreen(
                 }
             },
             onEmpty = {
-                NoDataScreen(
-                    icon = Icons.Outlined.FolderOff,
-                    showRetry = true,
-                    onRetry = { viewModel.onEvent(WhatsAppCleanerEvent.LoadMedia) }
-                )
+                WhatsAppDetailsEmptyState(paddingValues = paddingValues)
             },
             onSuccess = { data ->
                 LaunchedEffect(title) {
@@ -217,18 +212,7 @@ fun DetailsScreen(
                 }
 
                 if (tabFiles.isEmpty()) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .padding(paddingValues),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        NoDataScreen(
-                            icon = Icons.Outlined.FolderOff,
-                            showRetry = true,
-                            onRetry = { viewModel.onEvent(WhatsAppCleanerEvent.LoadMedia) }
-                        )
-                    }
+                    WhatsAppDetailsEmptyState(paddingValues = paddingValues)
                 } else {
 
                     val pagerState = rememberPagerState { tabs.size }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/components/states/WhatsAppDetailsEmptyState.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/components/states/WhatsAppDetailsEmptyState.kt
@@ -1,0 +1,85 @@
+package com.d4rk.cleaner.app.clean.whatsapp.details.ui.components.states
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.DoneAll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import com.airbnb.lottie.compose.LottieAnimation
+import com.airbnb.lottie.compose.LottieCompositionSpec
+import com.airbnb.lottie.compose.rememberLottieComposition
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
+import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.AdBanner
+import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeVerticalSpacer
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+import com.d4rk.cleaner.R
+import org.koin.compose.koinInject
+import org.koin.core.qualifier.named
+
+@Composable
+fun WhatsAppDetailsEmptyState(
+    paddingValues: PaddingValues,
+    adsConfig: AdsConfig = koinInject(qualifier = named(name = "banner_medium_rectangle"))
+) {
+    val composition by rememberLottieComposition(LottieCompositionSpec.RawRes(R.raw.finish_anim))
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(paddingValues)
+            .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            imageVector = Icons.Rounded.DoneAll,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.padding(bottom = SizeConstants.MediumSize)
+        )
+        Text(
+            text = stringResource(id = R.string.all_clean),
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(bottom = SizeConstants.SmallSize)
+        )
+        Text(
+            text = stringResource(id = R.string.whatsapp_details_empty_message),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(horizontal = SizeConstants.MediumSize)
+        )
+        LottieAnimation(
+            composition = composition,
+            iterations = 1,
+            speed = 1.2f,
+            contentScale = ContentScale.FillHeight,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(SizeConstants.ExtraExtraLargeSize.times(6))
+                .padding(vertical = SizeConstants.MediumSize)
+        )
+        LargeVerticalSpacer()
+        AdBanner(
+            adsConfig = adsConfig,
+            modifier = Modifier.padding(top = SizeConstants.MediumSize)
+        )
+    }
+}

--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -150,6 +150,7 @@
     <string name="all_clean">كل شيء نظيف</string>
     <string name="whatsapp_cleaner_empty_message">واتسابك نظيف تمامًا! لا شيء للتنظيف. استمتع بيومك!</string>
     <string name="contacts_cleaner_empty_message">جهات الاتصال منظمة بالفعل! لا يوجد ما يمكن تنظيفه.</string>
+    <string name="whatsapp_details_empty_message">كل شيء جاهز! لا توجد ملفات متبقية في هذه الفئة.</string>
     <string name="total_files_format">%1$s ملفات</string>
     <string name="delete_selected">حذف المحدد</string>
     <string name="sort_options">خيارات الفرز</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -134,6 +134,7 @@
     <string name="all_clean">Всички чисти</string>
     <string name="whatsapp_cleaner_empty_message">Вашият WhatsApp е безупречно чист! Няма нищо за почистване. Приятен ден!</string>
     <string name="contacts_cleaner_empty_message">Вашите контакти вече са подредени! Няма какво да чистите.</string>
+    <string name="whatsapp_details_empty_message">Всичко е готово! Няма останали файлове в тази категория.</string>
     <string name="total_files_format">%1$s файла</string>
     <string name="delete_selected">Изтриване на избраните</string>
     <string name="sort_options">Опции за сортиране</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -134,6 +134,7 @@
     <string name="all_clean">সব পরিষ্কার</string>
     <string name="whatsapp_cleaner_empty_message">আপনার হোয়াটসঅ্যাপ একদম পরিষ্কার! আর কিছু মুছতে নেই। আপনার দিন ভালো কাটুক!</string>
     <string name="contacts_cleaner_empty_message">আপনার পরিচিতিগুলো ইতিমধ্যেই সুশৃঙ্খল! পরিষ্কার করার মতো কিছু নেই।</string>
+    <string name="whatsapp_details_empty_message">সব প্রস্তুত! এই বিভাগে আর কোনো ফাইল নেই।</string>
     <string name="total_files_format">%1$s ফাইল</string>
     <string name="delete_selected">নির্বাচিত মুছে ফেলুন</string>
     <string name="sort_options">সাজানোর অপশন</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -134,6 +134,7 @@
     <string name="all_clean">Alles sauber</string>
     <string name="whatsapp_cleaner_empty_message">Dein WhatsApp ist blitzsauber! Es gibt nichts zu reinigen. Schönen Tag noch!</string>
     <string name="contacts_cleaner_empty_message">Deine Kontakte sind bereits organisiert! Nichts zum Bereinigen.</string>
+    <string name="whatsapp_details_empty_message">Alles erledigt! Keine Dateien mehr in dieser Kategorie.</string>
     <string name="total_files_format">%1$s Dateien</string>
     <string name="delete_selected">Ausgewählte löschen</string>
     <string name="sort_options">Sortieroptionen</string>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -138,6 +138,7 @@
     <string name="all_clean">Todo limpio</string>
     <string name="whatsapp_cleaner_empty_message">¡Tu WhatsApp está impecable! No hay nada que limpiar. ¡Disfruta tu día!</string>
     <string name="contacts_cleaner_empty_message">¡Tus contactos ya están organizados! No hay nada que limpiar.</string>
+    <string name="whatsapp_details_empty_message">¡Todo listo! No quedan archivos en esta categoría.</string>
     <string name="total_files_format">%1$s archivos</string>
     <string name="delete_selected">Eliminar seleccionados</string>
     <string name="sort_options">Opciones de ordenación</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -138,6 +138,7 @@
     <string name="all_clean">Todo limpio</string>
     <string name="whatsapp_cleaner_empty_message">¡Tu WhatsApp está impecable! No hay nada que limpiar. ¡Disfruta tu día!</string>
     <string name="contacts_cleaner_empty_message">¡Tus contactos ya están organizados! No hay nada que limpiar.</string>
+    <string name="whatsapp_details_empty_message">¡Todo listo! No quedan archivos en esta categoría.</string>
     <string name="total_files_format">%1$s archivos</string>
     <string name="delete_selected">Eliminar seleccionados</string>
     <string name="sort_options">Opciones de ordenación</string>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -134,6 +134,7 @@
     <string name="all_clean">Lahat malinis</string>
     <string name="whatsapp_cleaner_empty_message">Malinis na ang WhatsApp mo! Wala nang kailangang linisin. Enjoy sa araw mo!</string>
     <string name="contacts_cleaner_empty_message">Ayos na ang iyong mga contact! Wala nang dapat linisin.</string>
+    <string name="whatsapp_details_empty_message">Ayos na! Wala nang mga file sa kategoriyang ito.</string>
     <string name="total_files_format">%1$s na file</string>
     <string name="delete_selected">Burahin ang Napili</string>
     <string name="sort_options">Mga opsyon sa pagsasaayos</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -138,6 +138,7 @@
     <string name="all_clean">Tout propre</string>
     <string name="whatsapp_cleaner_empty_message">Votre WhatsApp est impeccable! Il n’y a plus rien à nettoyer. Bonne journée!</string>
     <string name="contacts_cleaner_empty_message">Vos contacts sont déjà organisés ! Rien à nettoyer.</string>
+    <string name="whatsapp_details_empty_message">Tout est prêt ! Plus aucun fichier dans cette catégorie.</string>
     <string name="total_files_format">%1$s fichiers</string>
     <string name="delete_selected">Supprimer la sélection</string>
     <string name="sort_options">Options de tri</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -134,6 +134,7 @@
     <string name="all_clean">सभी साफ</string>
     <string name="whatsapp_cleaner_empty_message">आपका WhatsApp एकदम साफ है! अब कुछ भी साफ़ नहीं करना है। अपना दिन आनंद से बिताएँ!</string>
     <string name="contacts_cleaner_empty_message">आपके कॉन्टैक्ट पहले से व्यवस्थित हैं! कुछ भी साफ़ करने की ज़रूरत नहीं।</string>
+    <string name="whatsapp_details_empty_message">सब तैयार है! इस श्रेणी में कोई फ़ाइल नहीं बची है।</string>
     <string name="total_files_format">%1$s फ़ाइलें</string>
     <string name="delete_selected">चयनित हटाएँ</string>
     <string name="sort_options">क्रमबद्ध विकल्प</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -134,6 +134,7 @@
     <string name="all_clean">Minden tiszta</string>
     <string name="whatsapp_cleaner_empty_message">A WhatsApp-od makulátlan! Nincs mit törölni. Szép napot!</string>
     <string name="contacts_cleaner_empty_message">A névjegyeid már rendezettek! Nincs mit tisztítani.</string>
+    <string name="whatsapp_details_empty_message">Minden kész! Ebben a kategóriában nem maradt fájl.</string>
     <string name="total_files_format">%1$s fájl</string>
     <string name="delete_selected">Kijelöltek törlése</string>
     <string name="sort_options">Rendezési beállítások</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -130,6 +130,7 @@
     <string name="all_clean">Semua bersih</string>
     <string name="whatsapp_cleaner_empty_message">WhatsApp Anda bersih! Tidak ada lagi yang perlu dibersihkan. Nikmati hari Anda!</string>
     <string name="contacts_cleaner_empty_message">Kontak Anda sudah tertata! Tidak ada yang perlu dibersihkan.</string>
+    <string name="whatsapp_details_empty_message">Semua siap! Tidak ada file yang tersisa dalam kategori ini.</string>
     <string name="total_files_format">%1$s file</string>
     <string name="delete_selected">Hapus yang Dipilih</string>
     <string name="sort_options">Opsi urutan</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -138,6 +138,7 @@
     <string name="all_clean">Tutto pulito</string>
     <string name="whatsapp_cleaner_empty_message">Il tuo WhatsApp è pulito! Non c’è più nulla da eliminare. Buona giornata!</string>
     <string name="contacts_cleaner_empty_message">I tuoi contatti sono già organizzati! Niente da pulire.</string>
+    <string name="whatsapp_details_empty_message">Tutto pronto! Nessun file rimasto in questa categoria.</string>
     <string name="total_files_format">%1$s file</string>
     <string name="delete_selected">Elimina selezionati</string>
     <string name="sort_options">Opzioni di ordinamento</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -130,6 +130,7 @@
     <string name="all_clean">すべてきれい</string>
     <string name="whatsapp_cleaner_empty_message">WhatsAppがきれいになりました！もう掃除するものはありません。良い一日を！</string>
     <string name="contacts_cleaner_empty_message">連絡先は既に整理されています。掃除するものはありません。</string>
+    <string name="whatsapp_details_empty_message">準備完了！このカテゴリにはファイルが残っていません。</string>
     <string name="total_files_format">%1$s 件のファイル</string>
     <string name="delete_selected">選択したものを削除</string>
     <string name="sort_options">並び替えオプション</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -130,6 +130,7 @@
     <string name="all_clean">모두 깨끗합니다</string>
     <string name="whatsapp_cleaner_empty_message">WhatsApp이 깔끔합니다! 더 이상 정리할 것이 없어요. 좋은 하루 보내세요!</string>
     <string name="contacts_cleaner_empty_message">연락처가 이미 정리되었습니다! 정리할 것이 없어요.</string>
+    <string name="whatsapp_details_empty_message">모두 정리되었습니다! 이 범주에 남은 파일이 없습니다.</string>
     <string name="total_files_format">%1$s개 파일</string>
     <string name="delete_selected">선택 삭제</string>
     <string name="sort_options">정렬 옵션</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -142,6 +142,7 @@
     <string name="all_clean">Wszystkie czyste</string>
     <string name="whatsapp_cleaner_empty_message">Twój WhatsApp jest czysty! Nie ma już nic do czyszczenia. Miłego dnia!</string>
     <string name="contacts_cleaner_empty_message">Twoje kontakty są już uporządkowane! Nie ma nic do czyszczenia.</string>
+    <string name="whatsapp_details_empty_message">Wszystko gotowe! W tej kategorii nie ma już plików.</string>
     <string name="total_files_format">%1$s plików</string>
     <string name="delete_selected">Usuń zaznaczone</string>
     <string name="sort_options">Opcje sortowania</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -138,6 +138,7 @@
     <string name="all_clean">Tudo limpo</string>
     <string name="whatsapp_cleaner_empty_message">Seu WhatsApp está limpo! Não há mais nada para limpar. Aproveite o seu dia!</string>
     <string name="contacts_cleaner_empty_message">Seus contatos já estão organizados! Nada para limpar.</string>
+    <string name="whatsapp_details_empty_message">Tudo certo! Não há mais arquivos nesta categoria.</string>
     <string name="total_files_format">%1$s arquivos</string>
     <string name="delete_selected">Excluir selecionados</string>
     <string name="sort_options">Opções de ordenação</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -138,6 +138,7 @@
     <string name="all_clean">Toate curate</string>
     <string name="whatsapp_cleaner_empty_message">WhatsApp-ul tău este impecabil! Nu mai ai ce curăța. Bucură-te de zi!</string>
     <string name="contacts_cleaner_empty_message">Contactele tale sunt deja organizate! Nu ai nimic de curățat.</string>
+    <string name="whatsapp_details_empty_message">Totul e pregătit! Nu mai există fișiere în această categorie.</string>
     <string name="total_files_format">%1$s fișiere</string>
     <string name="delete_selected">Șterge selecția</string>
     <string name="sort_options">Opțiuni de sortare</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -142,6 +142,7 @@
     <string name="all_clean">Все чисто</string>
     <string name="whatsapp_cleaner_empty_message">Ваш WhatsApp идеально чист! Больше нечего удалять. Хорошего дня!</string>
     <string name="contacts_cleaner_empty_message">Ваши контакты уже упорядочены! Нечего очищать.</string>
+    <string name="whatsapp_details_empty_message">Все готово! В этой категории не осталось файлов.</string>
     <string name="total_files_format">%1$s файлов</string>
     <string name="delete_selected">Удалить выбранные</string>
     <string name="sort_options">Параметры сортировки</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -134,6 +134,7 @@
     <string name="all_clean">Allt rent</string>
     <string name="whatsapp_cleaner_empty_message">Din WhatsApp är helt ren! Det finns inget mer att rensa. Ha en bra dag!</string>
     <string name="contacts_cleaner_empty_message">Dina kontakter är redan organiserade! Inget att rensa.</string>
+    <string name="whatsapp_details_empty_message">Allt klart! Inga filer kvar i den här kategorin.</string>
     <string name="total_files_format">%1$s filer</string>
     <string name="delete_selected">Ta bort valda</string>
     <string name="sort_options">Sorteringsalternativ</string>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -130,6 +130,7 @@
     <string name="all_clean">สะอาดทั้งหมด</string>
     <string name="whatsapp_cleaner_empty_message">WhatsApp ของคุณสะอาดหมดจด! ไม่มีอะไรให้ลบแล้ว ขอให้เป็นวันดีๆ!</string>
     <string name="contacts_cleaner_empty_message">รายชื่อติดต่อของคุณจัดเรียบร้อยแล้ว! ไม่มีอะไรให้ลบ</string>
+    <string name="whatsapp_details_empty_message">เรียบร้อยแล้ว! ไม่มีไฟล์เหลืออยู่ในหมวดหมู่นี้</string>
     <string name="total_files_format">%1$s ไฟล์</string>
     <string name="delete_selected">ลบที่เลือก</string>
     <string name="sort_options">ตัวเลือกการจัดเรียง</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -134,6 +134,7 @@
     <string name="all_clean">Hepsi temiz</string>
     <string name="whatsapp_cleaner_empty_message">WhatsApp\'ınız tertemiz! Temizlenecek bir şey kalmadı. İyi günler!</string>
     <string name="contacts_cleaner_empty_message">Kişileriniz zaten düzenli! Temizlenecek bir şey yok.</string>
+    <string name="whatsapp_details_empty_message">Her şey hazır! Bu kategoride dosya kalmadı.</string>
     <string name="total_files_format">%1$s dosya</string>
     <string name="delete_selected">Seçilenleri Sil</string>
     <string name="sort_options">Sıralama seçenekleri</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -142,6 +142,7 @@
     <string name="all_clean">Всі чисті</string>
     <string name="whatsapp_cleaner_empty_message">Ваш WhatsApp бездоганно чистий! Немає чого прибирати. Гарного дня!</string>
     <string name="contacts_cleaner_empty_message">Ваші контакти вже впорядковані! Нічого чистити.</string>
+    <string name="whatsapp_details_empty_message">Усе готово! У цій категорії не залишилося файлів.</string>
     <string name="total_files_format">%1$s файлів</string>
     <string name="delete_selected">Видалити вибране</string>
     <string name="sort_options">Параметри сортування</string>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -134,6 +134,7 @@
     <string name="all_clean">سب صاف</string>
     <string name="whatsapp_cleaner_empty_message">آپ کا واٹس ایپ بالکل صاف ہے! اب کچھ بھی صاف نہیں کرنا۔ اپنا دن اچھا گزاریں!</string>
     <string name="contacts_cleaner_empty_message">آپ کے رابطے پہلے ہی منظم ہیں! صفائی کی ضرورت نہیں۔</string>
+    <string name="whatsapp_details_empty_message">سب تیار ہے! اس زمرے میں کوئی فائل باقی نہیں ہے۔</string>
     <string name="total_files_format">%1$s فائلیں</string>
     <string name="delete_selected">منتخب حذف کریں</string>
     <string name="sort_options">ترتیب کے اختیارات</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -130,6 +130,7 @@
     <string name="all_clean">Tất cả đều sạch sẽ</string>
     <string name="whatsapp_cleaner_empty_message">WhatsApp của bạn sạch bóng! Không còn gì để dọn. Chúc bạn một ngày vui vẻ!</string>
     <string name="contacts_cleaner_empty_message">Danh bạ của bạn đã được sắp xếp! Không còn gì để dọn.</string>
+    <string name="whatsapp_details_empty_message">Hoàn tất! Không còn tệp nào trong danh mục này.</string>
     <string name="total_files_format">%1$s tệp</string>
     <string name="delete_selected">Xóa mục đã chọn</string>
     <string name="sort_options">Tùy chọn sắp xếp</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -130,6 +130,7 @@
     <string name="all_clean">全部乾淨</string>
     <string name="whatsapp_cleaner_empty_message">你的 WhatsApp 乾淨如新！沒有東西可清理。祝你有美好的一天！</string>
     <string name="contacts_cleaner_empty_message">你的聯絡人已經整理好了！沒有需要清理的。</string>
+    <string name="whatsapp_details_empty_message">全部搞定！此分類中已沒有檔案。</string>
     <string name="total_files_format">%1$s 個檔案</string>
     <string name="delete_selected">刪除已選</string>
     <string name="sort_options">排序選項</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,6 +139,7 @@
     <string name="all_clean">All clean</string>
     <string name="whatsapp_cleaner_empty_message">Your WhatsApp is spotless! There’s nothing left to clean. Enjoy your day!</string>
     <string name="contacts_cleaner_empty_message">Your contacts are already organized! Nothing to clean up.</string>
+    <string name="whatsapp_details_empty_message">You're all set! No files left in this category.</string>
     <string name="total_files_format">%1$s files</string>
     <string name="delete_selected">Delete Selected</string>
     <string name="sort_options">Sort options</string>


### PR DESCRIPTION
## Summary
- show animated finish Lottie when WhatsApp details have no data
- add WhatsApp details empty message string
- localize WhatsApp details empty message across supported languages

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d9f6376ec832daa7dbd149da918b2