### PR TITLE
Use Locale.ROOT for extension comparisons in AutoCleanWorker

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/auto/AutoCleanWorker.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/auto/AutoCleanWorker.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.flow.onEach
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.io.File
+import java.util.Locale
 import kotlin.time.Duration.Companion.days
 
 class AutoCleanWorker(
@@ -121,7 +122,7 @@ class AutoCleanWorker(
             if (includeDuplicates && file in duplicateFiles) {
                 result.add(file)
             } else {
-                val extension = file.extension.lowercase()
+                val extension = file.extension.lowercase(Locale.ROOT)
                 val match = when (extension) {
                     in fileTypesData.imageExtensions -> preferences[ExtensionsConstants.IMAGE_EXTENSIONS] == true
                     in fileTypesData.videoExtensions -> preferences[ExtensionsConstants.VIDEO_EXTENSIONS] == true
@@ -149,7 +150,7 @@ class AutoCleanWorker(
     ): List<List<File>> {
         val hashMap = mutableMapOf<String, MutableList<File>>()
         files.filter { it.isFile }.forEach { file ->
-            val extension = file.extension.lowercase()
+            val extension = file.extension.lowercase(Locale.ROOT)
             val hash = if (deepSearch && extension in imageExtensions) {
                 ImageHashUtils.perceptualHash(file)
             } else {


### PR DESCRIPTION
## Summary
- Import `java.util.Locale` for consistent case conversions
- Normalize file extensions with `lowercase(Locale.ROOT)` in cleanup routines

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689da7d65a8c832d9dd75261e6c6a520