### PR TITLE
Handle delete failure in AutoCleanWorker

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/auto/AutoCleanWorker.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/auto/AutoCleanWorker.kt
@@ -91,7 +91,15 @@ class AutoCleanWorker(
         )
         if (toDelete.isEmpty()) return Result.success()
 
-        deleteFiles(repository = repository, files = toDelete, mode = DeleteFilesUseCase.Mode.PERMANENT).collect {}
+        val deleteState = deleteFiles(
+            repository = repository,
+            files = toDelete,
+            mode = DeleteFilesUseCase.Mode.PERMANENT
+        ).first()
+        if (deleteState is DataState.Error) {
+            CleaningEventBus.notifyCleaned(success = false)
+            return Result.retry()
+        }
         dataStore.saveLastScanTimestamp(now)
         CleaningEventBus.notifyCleaned(success = true)
         return Result.success()


### PR DESCRIPTION
## Summary
- Handle error states from `deleteFiles` in AutoCleanWorker
- Update last scan timestamp only after successful deletion

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dab3bda28832da86e84c1d0ff691d