### PR TITLE
Fix APK icon preview loading

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/utils/helpers/FilePreviewHelper.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/utils/helpers/FilePreviewHelper.kt
@@ -427,10 +427,17 @@ object FilePreviewHelper {
                     }
                 }
                 Box(modifier = modifier.size(24.dp), contentAlignment = Alignment.Center) {
-                    IconLoadingPlaceholder(iconRes = R.drawable.ic_apk_document, modifier = Modifier.fillMaxSize())
-                    icon?.let { loaded ->
+                    if (icon == null) {
+                        IconLoadingPlaceholder(
+                            iconRes = R.drawable.ic_apk_document,
+                            modifier = Modifier.fillMaxSize()
+                        )
+                    } else {
                         AsyncImage(
-                            model = ImageRequest.Builder(context).data(loaded).crossfade(true).build(),
+                            model = ImageRequest.Builder(context)
+                                .data(icon)
+                                .crossfade(true)
+                                .build(),
                             contentDescription = file.name,
                             modifier = Modifier.fillMaxSize(),
                             contentScale = ContentScale.Fit


### PR DESCRIPTION
## Summary
- show APK icon only after it loads
- display loading placeholder only when the icon is missing

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ddf6ed1f0832da729840d622ec5c1