### PR TITLE
Refactor GetDuplicatesUseCase to suspend

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/domain/operations/FileAnalyzer.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/domain/operations/FileAnalyzer.kt
@@ -12,7 +12,7 @@ import java.io.File
 class FileAnalyzer(
     private val getDuplicatesUseCase: GetDuplicatesUseCase
 ) {
-    fun computeGroupedFiles(
+    suspend fun computeGroupedFiles(
         scannedFiles: List<File>,
         emptyFolders: List<File>,
         fileTypesData: FileTypesData,

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/domain/usecases/GetDuplicatesUseCase.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/domain/usecases/GetDuplicatesUseCase.kt
@@ -6,7 +6,6 @@ import com.d4rk.cleaner.core.utils.extensions.partialMd5
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
@@ -17,14 +16,14 @@ class GetDuplicatesUseCase(
     private val hashCache = ConcurrentHashMap<String, String>()
     private val chunkSize = 100
 
-    operator fun invoke(files: List<File>): List<List<FileEntry>> = runBlocking {
+    suspend operator fun invoke(files: List<File>): List<List<FileEntry>> {
         val candidates = files.filter { it.isFile }
             .groupBy { it.length() to it.lastModified() }
             .values
             .filter { it.size > 1 }
             .flatten()
 
-        if (candidates.isEmpty()) return@runBlocking emptyList()
+        if (candidates.isEmpty()) return emptyList()
 
         val hashed = coroutineScope {
             candidates.chunked(chunkSize).map { chunk ->
@@ -40,7 +39,7 @@ class GetDuplicatesUseCase(
             }.awaitAll().flatten()
         }
 
-        hashed.groupBy({ it.first }, { it.second })
+        return hashed.groupBy({ it.first }, { it.second })
             .values
             .filter { it.size > 1 }
             .map { group ->


### PR DESCRIPTION
## Summary
- Make `GetDuplicatesUseCase` a suspending operator
- Update `FileAnalyzer` to invoke the suspend duplicate scan

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689de5711784832dbdc2093b3ec501d5