### PR TITLE
Use path-based IDs for APK items

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/apps/manager/data/ApkFileManagerImpl.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/apps/manager/data/ApkFileManagerImpl.kt
@@ -67,7 +67,13 @@ class ApkFileManagerImpl(
                     if (file.extension.equals("apk", ignoreCase = true)) {
                         val path = file.absolutePath
                         if (file.exists() && file.canWrite() && addedPaths.add(path)) {
-                            apkFiles.add(ApkInfo(file.hashCode().toLong(), path, file.length()))
+                            apkFiles.add(
+                                ApkInfo(
+                                    id = path.hashCode().toLong(),
+                                    path = path,
+                                    size = file.length()
+                                )
+                            )
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Derive stable APK IDs from file path instead of file hash to improve RecyclerView diffing

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689de9a55450832da8135a6f54dfd311