### PR TITLE
Ensure cleanup dismiss finishes asynchronously

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/notifications/notifications/CleanupDismissReceiver.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/notifications/notifications/CleanupDismissReceiver.kt
@@ -11,11 +11,16 @@ import kotlin.time.Duration.Companion.days
 
 class CleanupDismissReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent?) {
+        val pending = goAsync()
         CoroutineScope(Dispatchers.IO).launch {
-            val store = DataStore(context)
-            store.saveCleanupNotificationSnoozedUntil(
-                System.currentTimeMillis() + 3.days.inWholeMilliseconds
-            )
+            try {
+                val store = DataStore(context)
+                store.saveCleanupNotificationSnoozedUntil(
+                    System.currentTimeMillis() + 3.days.inWholeMilliseconds
+                )
+            } finally {
+                pending.finish()
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Use `goAsync` and finish the pending result in `CleanupDismissReceiver`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a208bf5d90832da7c6571fba205527