### PR TITLE
feat: add badge support to grid card item

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/components/StorageBreakdownGrid.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/components/StorageBreakdownGrid.kt
@@ -44,6 +44,7 @@ fun StorageBreakdownGrid(
 
         GridCardItem(
             model = model,
+            badgeText = model.subtitle,
             iconContainerColor = GroupedGridStyle.iconContainerColor,
             onClick = { onItemClick(label) },
             iconShape = MaterialTheme.shapes.medium,

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/components/DirectoryCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/components/DirectoryCard.kt
@@ -18,6 +18,7 @@ fun DirectoryCard(
         iconPainter = painterResource(id = item.icon),
         title = item.name,
         subtitle = item.size,
+        badgeText = item.size,
         iconContainerColor = GroupedGridStyle.iconContainerColor,
         onClick = { onOpenDetails(item.type) },
     )

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/core/ui/components/GridCardItem.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/core/ui/components/GridCardItem.kt
@@ -8,8 +8,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Badge
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -33,6 +35,7 @@ fun GridCardItem(
     iconVector: ImageVector? = null,
     title: String,
     subtitle: String,
+    badgeText: String? = null,
     iconContainerColor: Color = GroupedGridStyle.iconContainerColor,
     iconShape: Shape = CircleShape,
     onClick: () -> Unit,
@@ -53,27 +56,39 @@ fun GridCardItem(
             Box(
                 modifier = Modifier
                     .padding(end = SizeConstants.SmallSize)
-                    .size(48.dp)
-                    .clip(iconShape)
-                    .background(iconContainerColor),
-                contentAlignment = Alignment.Center,
+                    .size(48.dp),
             ) {
-                when {
-                    iconPainter != null -> {
-                        Icon(
-                            modifier = Modifier.bounceClick(),
-                            painter = iconPainter,
-                            contentDescription = null,
-                            tint = Color.Unspecified,
-                        )
+                Box(
+                    modifier = Modifier
+                        .matchParentSize()
+                        .clip(iconShape)
+                        .background(iconContainerColor),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    when {
+                        iconPainter != null -> {
+                            Icon(
+                                modifier = Modifier.bounceClick(),
+                                painter = iconPainter,
+                                contentDescription = null,
+                                tint = Color.Unspecified,
+                            )
+                        }
+                        iconVector != null -> {
+                            Icon(
+                                modifier = Modifier.bounceClick(),
+                                imageVector = iconVector,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                            )
+                        }
                     }
-                    iconVector != null -> {
-                        Icon(
-                            modifier = Modifier.bounceClick(),
-                            imageVector = iconVector,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                        )
+                }
+                if (badgeText != null) {
+                    Badge(
+                        modifier = Modifier.align(Alignment.TopStart)
+                    ) {
+                        Text(text = badgeText)
                     }
                 }
             }
@@ -93,6 +108,7 @@ fun GridCardItem(
 fun GridCardItem(
     model: GridCardModel,
     modifier: Modifier = Modifier,
+    badgeText: String? = null,
     iconContainerColor: Color = GroupedGridStyle.iconContainerColor,
     iconShape: Shape = CircleShape,
     onClick: () -> Unit,
@@ -102,6 +118,7 @@ fun GridCardItem(
         iconVector = model.iconVector,
         title = model.title,
         subtitle = model.subtitle,
+        badgeText = badgeText,
         iconContainerColor = iconContainerColor,
         iconShape = iconShape,
         onClick = onClick,

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/core/ui/components/GridCardItem.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/core/ui/components/GridCardItem.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.matchParentSize
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Badge
@@ -60,7 +60,7 @@ fun GridCardItem(
             ) {
                 Box(
                     modifier = Modifier
-                        .matchParentSize()
+                        .fillMaxSize()
                         .clip(iconShape)
                         .background(iconContainerColor),
                     contentAlignment = Alignment.Center,


### PR DESCRIPTION
## Summary
- allow GridCardItem to display an optional badge text
- show badge on top-left of icon when size string is provided
- adopt new badgeText in directory and storage grid cards

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4db57e714832da84686f5bed681a5