### PR TITLE
Move badge from GridCardItem to FilesGrid

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/components/FileCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/components/FileCard.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.TooltipDefaults
@@ -24,12 +25,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
@@ -79,11 +82,15 @@ fun FileCard(
                 if (isOriginal) {
                     Text(
                         text = stringResource(id = R.string.original),
-                        color = Color.White,
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.Bold,
                         modifier = Modifier
                             .align(Alignment.TopStart)
-                            .background(Color.Red.copy(alpha = 0.7f))
-                            .padding(horizontal = 4.dp, vertical = SizeConstants.ExtraTinySize),
+                            .background(
+                                color = MaterialTheme.colorScheme.surfaceVariant,
+                                shape = RoundedCornerShape(bottomEnd = SizeConstants.ExtraLargeSize)
+                            )
+                            .padding(all = SizeConstants.MediumSize)
                     )
                 }
 

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/components/StorageBreakdownGrid.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/components/StorageBreakdownGrid.kt
@@ -44,7 +44,6 @@ fun StorageBreakdownGrid(
 
         GridCardItem(
             model = model,
-            badgeText = model.subtitle,
             iconContainerColor = GroupedGridStyle.iconContainerColor,
             onClick = { onItemClick(label) },
             iconShape = MaterialTheme.shapes.medium,

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/components/DirectoryCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/components/DirectoryCard.kt
@@ -18,7 +18,6 @@ fun DirectoryCard(
         iconPainter = painterResource(id = item.icon),
         title = item.name,
         subtitle = item.size,
-        badgeText = item.size,
         iconContainerColor = GroupedGridStyle.iconContainerColor,
         onClick = { onOpenDetails(item.type) },
     )

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/core/ui/components/GridCardItem.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/core/ui/components/GridCardItem.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.Badge
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -36,7 +35,6 @@ fun GridCardItem(
     iconVector: ImageVector? = null,
     title: String,
     subtitle: String,
-    badgeText: String? = null,
     iconContainerColor: Color = GroupedGridStyle.iconContainerColor,
     iconShape: Shape = CircleShape,
     onClick: () -> Unit,
@@ -84,13 +82,6 @@ fun GridCardItem(
                         }
                     }
                 }
-                if (badgeText != null) {
-                    Badge(
-                        modifier = Modifier.align(Alignment.TopStart)
-                    ) {
-                        Text(text = badgeText)
-                    }
-                }
             }
             Column(modifier = Modifier.weight(1f)) {
                 Text(
@@ -108,7 +99,6 @@ fun GridCardItem(
 fun GridCardItem(
     model: GridCardModel,
     modifier: Modifier = Modifier,
-    badgeText: String? = null,
     iconContainerColor: Color = GroupedGridStyle.iconContainerColor,
     iconShape: Shape = CircleShape,
     onClick: () -> Unit,
@@ -118,7 +108,6 @@ fun GridCardItem(
         iconVector = model.iconVector,
         title = model.title,
         subtitle = model.subtitle,
-        badgeText = badgeText,
         iconContainerColor = iconContainerColor,
         iconShape = iconShape,
         onClick = onClick,


### PR DESCRIPTION
## Summary
- Remove badge API from `GridCardItem` and clean up callers
- Apply styled `Text` badge to `FileCard` in FilesGrid for original files

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a777d35c832d9c17b997436c69fd